### PR TITLE
Feature/Implement DNS records factories

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -247,3 +247,6 @@ RSpec/MultipleDescribes:
 
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
+
+RSpec/StubbedMock:
+  Enabled: false

--- a/lib/dns_mock.rb
+++ b/lib/dns_mock.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'dns_mock/version'
+require_relative 'dns_mock/core'
 
 module DnsMock
   # Your code goes here...

--- a/lib/dns_mock/core.rb
+++ b/lib/dns_mock/core.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module DnsMock
+  require_relative '../dns_mock/version'
+
+  RecordTypeError = Class.new(StandardError) do
+    def initialize(record_type)
+      super("#{record_type} is invalid record type")
+    end
+  end
+
+  RecordContextError = Class.new(StandardError) do
+    def initialize(record_context, record_type)
+      super("#{record_context}. Invalid #{record_type} record context")
+    end
+  end
+
+  RecordContextTypeError = Class.new(StandardError) do
+    def initialize(record_context_type, expected_type)
+      super("#{record_context_type} is invalid record context type. Should be a #{expected_type}")
+    end
+  end
+
+  module Record
+    module Factory
+      require_relative '../dns_mock/record/factory/base'
+      require_relative '../dns_mock/record/factory/a'
+      require_relative '../dns_mock/record/factory/aaaa'
+      require_relative '../dns_mock/record/factory/ns'
+      require_relative '../dns_mock/record/factory/mx'
+      require_relative '../dns_mock/record/factory/txt'
+      require_relative '../dns_mock/record/factory/soa'
+      require_relative '../dns_mock/record/factory/cname'
+    end
+  end
+end

--- a/lib/dns_mock/record/factory/a.rb
+++ b/lib/dns_mock/record/factory/a.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Factory
+      A = Class.new(DnsMock::Record::Factory::Base) do
+        record_type :a
+
+        def instance_params
+          record_data
+        end
+      end
+    end
+  end
+end

--- a/lib/dns_mock/record/factory/aaaa.rb
+++ b/lib/dns_mock/record/factory/aaaa.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Factory
+      Aaaa = Class.new(DnsMock::Record::Factory::Base) do
+        record_type :aaaa
+
+        def instance_params
+          record_data
+        end
+      end
+    end
+  end
+end

--- a/lib/dns_mock/record/factory/base.rb
+++ b/lib/dns_mock/record/factory/base.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Factory
+      class Base
+        require 'resolv'
+
+        DNS_RECORD_TYPES = %i[a aaaa cname mx ns soa txt].freeze
+
+        class << self
+          attr_reader :target_class
+
+          def record_type(record_type)
+            @target_class = Resolv::DNS::Resource::IN.const_get(
+              record_type_check(record_type).upcase
+            )
+          end
+
+          private
+
+          def record_type_check(defined_record_type)
+            valid_record_type = DnsMock::Record::Factory::Base::DNS_RECORD_TYPES.include?(defined_record_type)
+            raise DnsMock::RecordTypeError, defined_record_type unless valid_record_type
+            defined_record_type
+          end
+        end
+
+        def initialize(dns_name = Resolv::DNS::Name, record_data:)
+          @dns_name = dns_name
+          @record_data = record_data
+        end
+
+        def instance_params; end
+
+        def create
+          self.class.target_class.public_send(:new, *instance_params)
+        rescue => error
+          raise DnsMock::RecordContextError.new(error.message, record_type)
+        end
+
+        private
+
+        attr_reader :dns_name, :record_data
+
+        def record_type
+          self.class.name.split('::').last.upcase
+        end
+      end
+    end
+  end
+end

--- a/lib/dns_mock/record/factory/cname.rb
+++ b/lib/dns_mock/record/factory/cname.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Factory
+      Cname = Class.new(DnsMock::Record::Factory::Base) do
+        record_type :cname
+
+        def instance_params
+          [dns_name.create(record_data)]
+        end
+      end
+    end
+  end
+end

--- a/lib/dns_mock/record/factory/mx.rb
+++ b/lib/dns_mock/record/factory/mx.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Factory
+      Mx = Class.new(DnsMock::Record::Factory::Base) do
+        record_type :mx
+
+        def instance_params
+          [record_data.first, dns_name.create(record_data.last)]
+        end
+      end
+    end
+  end
+end

--- a/lib/dns_mock/record/factory/ns.rb
+++ b/lib/dns_mock/record/factory/ns.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Factory
+      Ns = Class.new(DnsMock::Record::Factory::Base) do
+        record_type :ns
+
+        def instance_params
+          [dns_name.create(record_data)]
+        end
+      end
+    end
+  end
+end

--- a/lib/dns_mock/record/factory/soa.rb
+++ b/lib/dns_mock/record/factory/soa.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Factory
+      Soa = Class.new(DnsMock::Record::Factory::Base) do
+        record_type :soa
+
+        def instance_params
+          record_data
+        end
+      end
+    end
+  end
+end

--- a/lib/dns_mock/record/factory/txt.rb
+++ b/lib/dns_mock/record/factory/txt.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Factory
+      Txt = Class.new(DnsMock::Record::Factory::Base) do
+        record_type :txt
+
+        def instance_params
+          record_data
+        end
+      end
+    end
+  end
+end

--- a/spec/dns_mock/core_spec.rb
+++ b/spec/dns_mock/core_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::RecordTypeError do
+  subject(:error_instance) { described_class.new('record_type') }
+
+  let(:error_context) { 'record_type is invalid record type' }
+
+  it_behaves_like 'customized error'
+end
+
+RSpec.describe DnsMock::RecordContextError do
+  subject(:error_instance) { described_class.new('record_data', 'record_type') }
+
+  let(:error_context) { 'record_data. Invalid record_type record context' }
+
+  it_behaves_like 'customized error'
+end
+
+RSpec.describe DnsMock::RecordContextTypeError do
+  subject(:error_instance) { described_class.new('record_context_type', 'expected_type') }
+
+  let(:error_context) { 'record_context_type is invalid record context type. Should be a expected_type' }
+
+  it_behaves_like 'customized error'
+end

--- a/spec/dns_mock/record/factory/a_spec.rb
+++ b/spec/dns_mock/record/factory/a_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Record::Factory::A do
+  it { expect(described_class).to be < DnsMock::Record::Factory::Base }
+
+  describe '#instance_params' do
+    subject(:instance_params) { described_class.new(record_data: record_data).instance_params }
+
+    let(:record_data) { 'some_record_context' }
+
+    it 'returns prepared target class instance params' do
+      expect(instance_params).to eq(record_data)
+    end
+  end
+
+  describe '#create' do
+    subject(:create_factory) { described_class.new(record_data: record_data).create }
+
+    context 'when valid record context' do
+      let(:record_data) { Faker::Internet.ip_v4_address }
+
+      it 'returns instance of target class' do
+        expect(create_factory).to be_an_instance_of(described_class.target_class)
+        expect(create_factory.address.to_s).to eq(record_data)
+      end
+    end
+
+    context 'when invalid record context' do
+      let(:record_data) { 'not_ip_v4_address' }
+      let(:error_context) { "cannot interpret as IPv4 address: \"#{record_data}\". Invalid A record context" }
+
+      it_behaves_like 'target class exception wrapper'
+    end
+  end
+end

--- a/spec/dns_mock/record/factory/aaaa_spec.rb
+++ b/spec/dns_mock/record/factory/aaaa_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Record::Factory::Aaaa do
+  it { expect(described_class).to be < DnsMock::Record::Factory::Base }
+
+  describe '#instance_params' do
+    subject(:instance_params) { described_class.new(record_data: record_data).instance_params }
+
+    let(:record_data) { 'some_record_context' }
+
+    it 'returns prepared target class instance params' do
+      expect(instance_params).to eq(record_data)
+    end
+  end
+
+  describe '#create' do
+    subject(:create_factory) { described_class.new(record_data: record_data).create }
+
+    context 'when valid record context' do
+      let(:record_data) { Faker::Internet.ip_v6_address }
+
+      it 'returns instance of target class' do
+        expect(create_factory).to be_an_instance_of(described_class.target_class)
+        expect(create_factory.address.to_s).to eq(record_data.upcase)
+      end
+    end
+
+    context 'when invalid record context' do
+      let(:record_data) { 'not_ip_v6_address' }
+      let(:error_context) { "not numeric IPv6 address: #{record_data}. Invalid AAAA record context" }
+
+      it_behaves_like 'target class exception wrapper'
+    end
+  end
+end

--- a/spec/dns_mock/record/factory/base_spec.rb
+++ b/spec/dns_mock/record/factory/base_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Record::Factory::Base do
+  describe 'defined constants' do
+    specify { expect(described_class).to be_const_defined(:DNS_RECORD_TYPES) }
+  end
+
+  describe '.record_type' do
+    subject(:record_type) { Class.new(described_class).record_type(defined_record_type) }
+
+    context 'when invalid record type' do
+      let(:defined_record_type) { :invalid_record_type }
+
+      it do
+        expect { record_type }
+          .to raise_error(DnsMock::RecordTypeError, "#{defined_record_type} is invalid record type")
+      end
+    end
+  end
+end

--- a/spec/dns_mock/record/factory/cname_spec.rb
+++ b/spec/dns_mock/record/factory/cname_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Record::Factory::Cname do
+  it { expect(described_class).to be < DnsMock::Record::Factory::Base }
+
+  describe '#instance_params' do
+    subject(:instance_params) { described_class.new(dns_name, record_data: record_data).instance_params }
+
+    let(:dns_name) { class_double('DnsName') }
+    let(:dns_name_instance) { instance_double('DnsName') }
+    let(:record_data) { 'some_record_context' }
+
+    it 'returns prepared target class instance params' do
+      expect(dns_name).to receive(:create).with(record_data).and_return(dns_name_instance)
+      expect(instance_params).to eq([dns_name_instance])
+    end
+  end
+
+  describe '#create' do
+    subject(:create_factory) { described_class.new(record_data: record_data).create }
+
+    context 'when valid record context' do
+      let(:record_data) { Faker::Internet.domain_name }
+
+      it 'returns instance of target class' do
+        expect(create_factory).to be_an_instance_of(described_class.target_class)
+        expect(create_factory.name.to_s).to eq(record_data)
+      end
+    end
+
+    context 'when invalid record context' do
+      let(:record_data) { [] }
+      let(:error_context) { "cannot interpret as DNS name: #{record_data}. Invalid CNAME record context" }
+
+      it_behaves_like 'target class exception wrapper'
+    end
+  end
+end

--- a/spec/dns_mock/record/factory/mx_spec.rb
+++ b/spec/dns_mock/record/factory/mx_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Record::Factory::Mx do
+  it { expect(described_class).to be < DnsMock::Record::Factory::Base }
+
+  describe '#instance_params' do
+    subject(:instance_params) { described_class.new(dns_name, record_data: record_data).instance_params }
+
+    let(:dns_name) { class_double('DnsName') }
+    let(:dns_name_instance) { instance_double('DnsName') }
+    let(:record_data) { %w[mx_preference mx_domain] }
+
+    it 'returns prepared target class instance params' do
+      expect(dns_name).to receive(:create).with(record_data.last).and_return(dns_name_instance)
+      expect(instance_params).to eq([record_data.first, dns_name_instance])
+    end
+  end
+
+  describe '#create' do
+    subject(:create_factory) { described_class.new(record_data: record_data).create }
+
+    context 'when valid record context' do
+      let(:record_data) { [10, Faker::Internet.domain_name] }
+
+      it 'returns instance of target class' do
+        expect(create_factory).to be_an_instance_of(described_class.target_class)
+        expect(create_factory.preference).to eq(record_data.first)
+        expect(create_factory.exchange.to_s).to eq(record_data.last)
+      end
+    end
+
+    context 'when invalid record context' do
+      let(:record_data) { [1, 2] }
+      let(:error_context) { "cannot interpret as DNS name: #{record_data.last}. Invalid MX record context" }
+
+      it_behaves_like 'target class exception wrapper'
+    end
+  end
+end

--- a/spec/dns_mock/record/factory/ns_spec.rb
+++ b/spec/dns_mock/record/factory/ns_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Record::Factory::Ns do
+  it { expect(described_class).to be < DnsMock::Record::Factory::Base }
+
+  describe '#instance_params' do
+    subject(:instance_params) { described_class.new(dns_name, record_data: record_data).instance_params }
+
+    let(:dns_name) { class_double('DnsName') }
+    let(:dns_name_instance) { instance_double('DnsName') }
+    let(:record_data) { 'some_record_context' }
+
+    it 'returns prepared target class instance params' do
+      expect(dns_name).to receive(:create).with(record_data).and_return(dns_name_instance)
+      expect(instance_params).to eq([dns_name_instance])
+    end
+  end
+
+  describe '#create' do
+    subject(:create_factory) { described_class.new(record_data: record_data).create }
+
+    context 'when valid record context' do
+      let(:record_data) { Faker::Internet.domain_name }
+
+      it 'returns instance of target class' do
+        expect(create_factory).to be_an_instance_of(described_class.target_class)
+        expect(create_factory.name.to_s).to eq(record_data)
+      end
+    end
+
+    context 'when invalid record context' do
+      let(:record_data) { 42 }
+      let(:error_context) { "cannot interpret as DNS name: #{record_data}. Invalid NS record context" }
+
+      it_behaves_like 'target class exception wrapper'
+    end
+  end
+end

--- a/spec/dns_mock/record/factory/soa_spec.rb
+++ b/spec/dns_mock/record/factory/soa_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Record::Factory::Soa do
+  it { expect(described_class).to be < DnsMock::Record::Factory::Base }
+
+  describe '#instance_params' do
+    subject(:instance_params) { described_class.new(record_data: record_data).instance_params }
+
+    let(:record_data) { 'some_record_context' }
+
+    it 'returns prepared target class instance params' do
+      expect(instance_params).to eq(record_data)
+    end
+  end
+
+  describe '#create' do
+    subject(:create_factory) { described_class.new(record_data: record_data.values).create }
+
+    let(:record_data) do
+      {
+        mname: 'dns1.domain.com',
+        rname: 'dns2.domain.com',
+        serial: 2_035_971_683,
+        refresh: 10_000,
+        retry: 2_400,
+        expire: 604_800,
+        minimum: 3_600
+      }
+    end
+
+    it 'returns instance of target class' do
+      expect(create_factory).to be_an_instance_of(described_class.target_class)
+      record_data.each { |key, value| expect(create_factory.public_send(key)).to eq(value) }
+    end
+  end
+end

--- a/spec/dns_mock/record/factory/txt_spec.rb
+++ b/spec/dns_mock/record/factory/txt_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Record::Factory::Txt do
+  it { expect(described_class).to be < DnsMock::Record::Factory::Base }
+
+  describe '#instance_params' do
+    subject(:instance_params) { described_class.new(record_data: record_data).instance_params }
+
+    let(:record_data) { 'some_record_context' }
+
+    it 'returns prepared target class instance params' do
+      expect(instance_params).to eq(record_data)
+    end
+  end
+
+  describe '#create' do
+    subject(:create_factory) { described_class.new(record_data: record_data).create }
+
+    let(:record_data) { Faker::Internet.uuid }
+
+    it 'returns instance of target class' do
+      expect(create_factory).to be_an_instance_of(described_class.target_class)
+      expect(create_factory.strings).to eq([record_data])
+    end
+  end
+end

--- a/spec/dns_mock/version_spec.rb
+++ b/spec/dns_mock/version_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::VERSION do
+  it { is_expected.not_to be_nil }
+end

--- a/spec/dns_mock_spec.rb
+++ b/spec/dns_mock_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.describe DnsMock do
-  it 'has a version number' do
-    expect(DnsMock::VERSION).not_to be(nil)
-  end
-end

--- a/spec/support/shared_examples/customized_error.rb
+++ b/spec/support/shared_examples/customized_error.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DnsMock
+  RSpec.shared_examples 'customized error' do
+    it { expect(described_class).to be < StandardError }
+    it { expect(error_instance).to be_an_instance_of(described_class) }
+    it { expect(error_instance.to_s).to eq(error_context) }
+  end
+end

--- a/spec/support/shared_examples/target_class_exception_wrapper.rb
+++ b/spec/support/shared_examples/target_class_exception_wrapper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DnsMock
+  RSpec.shared_examples 'target class exception wrapper' do
+    it 'wraps target class exception and raises as customized error' do
+      expect { create_factory }.to raise_error(DnsMock::RecordContextError, error_context)
+    end
+  end
+end


### PR DESCRIPTION
The first part of user input processing.

- [x] Implemented `DnsMock::Record::Factory::Base`
- [x] Implemented `DnsMock::Record::Factory::A`
- [x] Implemented `DnsMock::Record::Factory::Aaaa`
- [x] Implemented `DnsMock::Record::Factory::Cname`
- [x] Implemented `DnsMock::Record::Factory::Mx`
- [x] Implemented `DnsMock::Record::Factory::Ns`
- [x] Implemented `DnsMock::Record::Factory::Soa`
- [x] Implemented `DnsMock::Record::Factory::Txt`
- [x] Implemented base library exceptions