### PR TITLE
Feature/Implement DNS record builders

### DIFF
--- a/lib/dns_mock/core.rb
+++ b/lib/dns_mock/core.rb
@@ -26,11 +26,24 @@ module DnsMock
       require_relative '../dns_mock/record/factory/base'
       require_relative '../dns_mock/record/factory/a'
       require_relative '../dns_mock/record/factory/aaaa'
-      require_relative '../dns_mock/record/factory/ns'
-      require_relative '../dns_mock/record/factory/mx'
-      require_relative '../dns_mock/record/factory/txt'
-      require_relative '../dns_mock/record/factory/soa'
       require_relative '../dns_mock/record/factory/cname'
+      require_relative '../dns_mock/record/factory/mx'
+      require_relative '../dns_mock/record/factory/ns'
+      require_relative '../dns_mock/record/factory/soa'
+      require_relative '../dns_mock/record/factory/txt'
+    end
+  end
+
+  module Record
+    module Builder
+      require_relative '../dns_mock/record/builder/base'
+      require_relative '../dns_mock/record/builder/a'
+      require_relative '../dns_mock/record/builder/aaaa'
+      require_relative '../dns_mock/record/builder/cname'
+      require_relative '../dns_mock/record/builder/mx'
+      require_relative '../dns_mock/record/builder/ns'
+      require_relative '../dns_mock/record/builder/soa'
+      require_relative '../dns_mock/record/builder/txt'
     end
   end
 end

--- a/lib/dns_mock/record/builder/a.rb
+++ b/lib/dns_mock/record/builder/a.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Builder
+      A = Class.new(DnsMock::Record::Builder::Base)
+    end
+  end
+end

--- a/lib/dns_mock/record/builder/aaaa.rb
+++ b/lib/dns_mock/record/builder/aaaa.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Builder
+      Aaaa = Class.new(DnsMock::Record::Builder::Base)
+    end
+  end
+end

--- a/lib/dns_mock/record/builder/base.rb
+++ b/lib/dns_mock/record/builder/base.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Builder
+      class Base
+        def self.call(target_factory, records_data)
+          new(target_factory, records_data).build
+        end
+
+        def initialize(target_factory, records_data)
+          @target_factory = target_factory
+          @records_data = records_data
+        end
+
+        def build
+          records_data.map { |record_data| target_factory.new(record_data: record_data).create }
+        end
+
+        private
+
+        attr_reader :target_factory, :records_data
+      end
+    end
+  end
+end

--- a/lib/dns_mock/record/builder/cname.rb
+++ b/lib/dns_mock/record/builder/cname.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Builder
+      Cname = Class.new(DnsMock::Record::Builder::Base) do
+        def build
+          [target_factory.new(record_data: records_data).create]
+        end
+      end
+    end
+  end
+end

--- a/lib/dns_mock/record/builder/mx.rb
+++ b/lib/dns_mock/record/builder/mx.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Builder
+      class Mx < DnsMock::Record::Builder::Base
+        RECORD_PREFERENCE_STEP = 10
+
+        def build
+          records_data.map.with_index(1) do |record_data, record_preference|
+            target_factory.new(
+              record_data: [
+                record_preference * DnsMock::Record::Builder::Mx::RECORD_PREFERENCE_STEP,
+                record_data
+              ]
+            ).create
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dns_mock/record/builder/ns.rb
+++ b/lib/dns_mock/record/builder/ns.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Builder
+      Ns = Class.new(DnsMock::Record::Builder::Base)
+    end
+  end
+end

--- a/lib/dns_mock/record/builder/soa.rb
+++ b/lib/dns_mock/record/builder/soa.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Builder
+      class Soa < DnsMock::Record::Builder::Base
+        FACTORY_ARGS_ORDER = %i[mname rname serial refresh retry expire minimum].freeze
+
+        def build
+          records_data.map do |record_data|
+            target_factory.new(
+              record_data: record_data.values_at(*DnsMock::Record::Builder::Soa::FACTORY_ARGS_ORDER)
+            ).create
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dns_mock/record/builder/txt.rb
+++ b/lib/dns_mock/record/builder/txt.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Builder
+      Txt = Class.new(DnsMock::Record::Builder::Base)
+    end
+  end
+end

--- a/spec/dns_mock/record/builder/a_spec.rb
+++ b/spec/dns_mock/record/builder/a_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Record::Builder::A do
+  include_context 'base builder behaviour'
+end

--- a/spec/dns_mock/record/builder/aaaa_spec.rb
+++ b/spec/dns_mock/record/builder/aaaa_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Record::Builder::Aaaa do
+  include_context 'base builder behaviour'
+end

--- a/spec/dns_mock/record/builder/cname_spec.rb
+++ b/spec/dns_mock/record/builder/cname_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Record::Builder::Cname do
+  describe 'class dependencies' do
+    subject(:builder_class) { described_class }
+
+    it { is_expected.to be < DnsMock::Record::Builder::Base }
+  end
+
+  describe '.call' do
+    subject(:builder) { described_class.call(target_factory, record_data) }
+
+    let(:target_factory) { class_double('TargetFactory') }
+    let(:target_class_instance) { instance_double('TargetClass') }
+    let(:target_factory_instance) { instance_double('TargetFactory', create: target_class_instance) }
+    let(:record_data) { 'record_data' }
+
+    it 'returns array with one target class instance' do
+      expect(target_factory).to receive(:new).with(record_data: record_data).and_return(target_factory_instance)
+      expect(builder).to eq([target_class_instance])
+    end
+  end
+end

--- a/spec/dns_mock/record/builder/mx_spec.rb
+++ b/spec/dns_mock/record/builder/mx_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Record::Builder::Mx do
+  describe 'class dependencies' do
+    subject(:builder_class) { described_class }
+
+    it { is_expected.to be < DnsMock::Record::Builder::Base }
+    it { is_expected.to be_const_defined(:RECORD_PREFERENCE_STEP) }
+  end
+
+  describe '.call' do
+    subject(:builder) { described_class.call(target_factory, records_data) }
+
+    let(:target_factory) { class_double('TargetFactory') }
+    let(:target_class_instance) { instance_double('TargetClass') }
+    let(:target_factory_instance) { instance_double('TargetFactory', create: target_class_instance) }
+    let(:records_data) { (0..2) }
+
+    it 'returns array of target class instances' do
+      [10, 20, 30].zip(records_data).each do |record_preference, record_data|
+        expect(target_factory)
+          .to receive(:new)
+          .with(record_data: [record_preference, record_data])
+          .and_return(target_factory_instance)
+      end
+      expect(builder).to eq(Array.new(records_data.size) { target_class_instance })
+    end
+  end
+end

--- a/spec/dns_mock/record/builder/ns_spec.rb
+++ b/spec/dns_mock/record/builder/ns_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Record::Builder::Ns do
+  include_context 'base builder behaviour'
+end

--- a/spec/dns_mock/record/builder/soa_spec.rb
+++ b/spec/dns_mock/record/builder/soa_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Record::Builder::Soa do
+  describe 'class dependencies' do
+    subject(:builder_class) { described_class }
+
+    it { is_expected.to be < DnsMock::Record::Builder::Base }
+    it { is_expected.to be_const_defined(:FACTORY_ARGS_ORDER) }
+  end
+
+  describe '.call' do
+    subject(:builder) { described_class.call(target_factory, records_data) }
+
+    let(:target_factory) { class_double('TargetFactory') }
+    let(:target_class_instance) { instance_double('TargetClass') }
+    let(:target_factory_instance) { instance_double('TargetFactory', create: target_class_instance) }
+    let(:records_data) do
+      (1..12).each_slice(6).map do |chunk|
+        DnsMock::Record::Builder::Soa::FACTORY_ARGS_ORDER.zip(chunk).to_h
+      end
+    end
+
+    it 'returns array of target class instances' do
+      records_data.each do |record_data|
+        expect(target_factory)
+          .to receive(:new)
+          .with(record_data: record_data.values)
+          .and_return(target_factory_instance)
+      end
+      expect(builder).to eq(Array.new(records_data.size) { target_class_instance })
+    end
+  end
+end

--- a/spec/dns_mock/record/builder/txt_spec.rb
+++ b/spec/dns_mock/record/builder/txt_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Record::Builder::Txt do
+  include_context 'base builder behaviour'
+end

--- a/spec/support/shared_contexts/base_builder_behaviour.rb
+++ b/spec/support/shared_contexts/base_builder_behaviour.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module DnsMock
+  RSpec.shared_context 'base builder behaviour' do
+    describe 'class dependencies' do
+      subject(:builder_class) { described_class }
+
+      it { is_expected.to be < DnsMock::Record::Builder::Base }
+    end
+
+    describe '.call' do
+      subject(:builder) { described_class.call(target_factory, records_data) }
+
+      let(:target_factory) { class_double('TargetFactory') }
+      let(:target_class_instance) { instance_double('TargetClass') }
+      let(:target_factory_instance) { instance_double('TargetFactory', create: target_class_instance) }
+      let(:records_data) { (0..rand(1..10)) }
+
+      it 'returns array of target class instances' do
+        records_data.each do |record_data|
+          expect(target_factory)
+            .to receive(:new)
+            .with(record_data: record_data)
+            .and_return(target_factory_instance)
+        end
+        expect(builder).to eq(Array.new(records_data.size) { target_class_instance })
+      end
+    end
+  end
+end


### PR DESCRIPTION
The second part of user input processing.

- [x] Implement `DnsMock::Record::Builder::Base`
- [x] Implement `DnsMock::Record::Builder::A`
- [x] Implement `DnsMock::Record::Builder::Aaaa`
- [x] Implement `DnsMock::Record::Builder::Cname`
- [x] Implement `DnsMock::Record::Builder::Mx`
- [x] Implement `DnsMock::Record::Builder::Ns`
- [x] Implement `DnsMock::Record::Builder::Soa`
- [x] Implement `DnsMock::Record::Builder::Txt`