### PR TITLE
Feature/Implement DNS records dictionary builder

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -1,3 +1,15 @@
 detectors:
   IrresponsibleModule:
     enabled: false
+
+  NestedIterators:
+    exclude:
+      - DnsMock::RecordsDictionaryBuilder#build
+
+  UtilityFunction:
+    exclude:
+      - DnsMock::RecordsDictionaryBuilder#build_records_instances_by_type
+
+  ControlParameter:
+    exclude:
+      - DnsMock::Helper::Error#raise_record_type_error

--- a/lib/dns_mock/core.rb
+++ b/lib/dns_mock/core.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module DnsMock
-  require_relative '../dns_mock/version'
+  AVAILABLE_DNS_RECORD_TYPES = %i[a aaaa cname mx ns soa txt].freeze
 
   RecordTypeError = Class.new(StandardError) do
     def initialize(record_type)
@@ -16,9 +16,17 @@ module DnsMock
   end
 
   RecordContextTypeError = Class.new(StandardError) do
-    def initialize(record_context_type, expected_type)
-      super("#{record_context_type} is invalid record context type. Should be a #{expected_type}")
+    def initialize(record_context_type, record_type, expected_record_context_type)
+      super(
+        "#{record_context_type} is invalid record context type for " \
+        "#{record_type} record. Should be a " \
+        "#{expected_record_context_type}"
+      )
     end
+  end
+
+  module Helper
+    require_relative '../dns_mock/helper/error'
   end
 
   module Record
@@ -46,4 +54,7 @@ module DnsMock
       require_relative '../dns_mock/record/builder/txt'
     end
   end
+
+  require_relative '../dns_mock/version'
+  require_relative '../dns_mock/records_dictionary_builder'
 end

--- a/lib/dns_mock/helper/error.rb
+++ b/lib/dns_mock/helper/error.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Helper
+    module Error
+      def raise_record_type_error(record_type, condition)
+        raise DnsMock::RecordTypeError, record_type unless condition
+      end
+
+      def raise_record_context_type_error(record_type, record_context, expected_type)
+        current_type, record_type = record_context.class, record_type.upcase
+        raise DnsMock::RecordContextTypeError.new(current_type, record_type, expected_type) unless current_type.eql?(expected_type)
+      end
+    end
+  end
+end

--- a/lib/dns_mock/record/factory/base.rb
+++ b/lib/dns_mock/record/factory/base.rb
@@ -5,8 +5,7 @@ module DnsMock
     module Factory
       class Base
         require 'resolv'
-
-        DNS_RECORD_TYPES = %i[a aaaa cname mx ns soa txt].freeze
+        extend DnsMock::Helper::Error
 
         class << self
           attr_reader :target_class
@@ -20,8 +19,7 @@ module DnsMock
           private
 
           def record_type_check(defined_record_type)
-            valid_record_type = DnsMock::Record::Factory::Base::DNS_RECORD_TYPES.include?(defined_record_type)
-            raise DnsMock::RecordTypeError, defined_record_type unless valid_record_type
+            raise_record_type_error(defined_record_type, DnsMock::AVAILABLE_DNS_RECORD_TYPES.include?(defined_record_type))
             defined_record_type
           end
         end

--- a/lib/dns_mock/records_dictionary_builder.rb
+++ b/lib/dns_mock/records_dictionary_builder.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module DnsMock
+  class RecordsDictionaryBuilder
+    include DnsMock::Helper::Error
+
+    TYPE_MAPPER = DnsMock::AVAILABLE_DNS_RECORD_TYPES.zip(
+      [
+        [DnsMock::Record::Builder::A, DnsMock::Record::Factory::A, ::Array],
+        [DnsMock::Record::Builder::Aaaa, DnsMock::Record::Factory::Aaaa, ::Array],
+        [DnsMock::Record::Builder::Cname, DnsMock::Record::Factory::Cname, ::String],
+        [DnsMock::Record::Builder::Mx, DnsMock::Record::Factory::Mx, ::Array],
+        [DnsMock::Record::Builder::Ns, DnsMock::Record::Factory::Ns, ::Array],
+        [DnsMock::Record::Builder::Soa, DnsMock::Record::Factory::Soa, ::Array],
+        [DnsMock::Record::Builder::Txt, DnsMock::Record::Factory::Txt, ::Array]
+      ]
+    ).to_h.freeze
+
+    def self.call(records_to_build)
+      new.build(records_to_build).records
+    end
+
+    attr_reader :records
+
+    def initialize
+      @records = {}
+    end
+
+    def build(records_to_build)
+      records_to_build.each do |hostname, dns_records|
+        records[hostname] = dns_records.each_with_object({}) do |(record_type, records_data), records_instances_by_type|
+          records_instances_by_type[record_type] = build_records_instances_by_type(record_type, records_data)
+        end
+      end
+
+      self
+    end
+
+    private
+
+    def build_records_instances_by_type(record_type, records_to_build)
+      target_builder, target_factory, expected_type = DnsMock::RecordsDictionaryBuilder::TYPE_MAPPER[record_type]
+      raise_record_type_error(record_type, target_builder)
+      raise_record_context_type_error(record_type, records_to_build, expected_type)
+      target_builder.call(target_factory, records_to_build)
+    end
+  end
+end

--- a/spec/dns_mock/core_spec.rb
+++ b/spec/dns_mock/core_spec.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+RSpec.describe DnsMock do
+  describe 'defined constants' do
+    it { expect(described_class).to be_const_defined(:AVAILABLE_DNS_RECORD_TYPES) }
+  end
+end
+
 RSpec.describe DnsMock::RecordTypeError do
   subject(:error_instance) { described_class.new('record_type') }
 
@@ -17,9 +23,9 @@ RSpec.describe DnsMock::RecordContextError do
 end
 
 RSpec.describe DnsMock::RecordContextTypeError do
-  subject(:error_instance) { described_class.new('record_context_type', 'expected_type') }
+  subject(:error_instance) { described_class.new('record_context_type', 'record_type', 'expected_type') }
 
-  let(:error_context) { 'record_context_type is invalid record context type. Should be a expected_type' }
+  let(:error_context) { 'record_context_type is invalid record context type for record_type record. Should be a expected_type' }
 
   it_behaves_like 'customized error'
 end

--- a/spec/dns_mock/record/factory/base_spec.rb
+++ b/spec/dns_mock/record/factory/base_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe DnsMock::Record::Factory::Base do
-  describe 'defined constants' do
-    specify { expect(described_class).to be_const_defined(:DNS_RECORD_TYPES) }
-  end
-
   describe '.record_type' do
     subject(:record_type) { Class.new(described_class).record_type(defined_record_type) }
 

--- a/spec/dns_mock/records_dictionary_builder_spec.rb
+++ b/spec/dns_mock/records_dictionary_builder_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::RecordsDictionaryBuilder do
+  describe 'defined constants' do
+    it { expect(described_class).to be_const_defined(:TYPE_MAPPER) }
+  end
+
+  describe '.call' do
+    subject(:records_dictionary_builder) { described_class.call(records_to_build) }
+
+    before { stub_const('DnsMock::RecordsDictionaryBuilder::TYPE_MAPPER', type_mapper) }
+
+    describe 'Success' do
+      let(:target_domain_1) { Faker::Internet.domain_name }
+      let(:target_domain_2) { Faker::Internet.domain_name }
+      let(:record_type_1) { :record_type_1 }
+      let(:record_type_2) { :record_type_2 }
+      let(:record_type_3) { :record_type_3 }
+      let(:target_builder_1) { class_double('TargetBuilderOne') }
+      let(:target_builder_2) { class_double('TargetBuilderTwo') }
+      let(:target_builder_3) { class_double('TargetBuilderThree') }
+      let(:target_factory_1) { class_double('TargetFactoryOne') }
+      let(:target_factory_2) { class_double('TargetFactoryTwo') }
+      let(:target_factory_3) { class_double('TargetFactoryThree') }
+      let(:builder_result_1) { [instance_double('TargetClassOne')] }
+      let(:builder_result_2) { [instance_double('TargetClassTwo')] }
+      let(:builder_result_3) { [instance_double('TargetClassThree')] * 2 }
+      let(:records_context_1) { %w[a b c] }
+      let(:records_context_2) { 'record_context' }
+      let(:records_context_3) { %w[d e f] }
+      let(:expected_records_to_build_type_1) { records_context_1.class }
+      let(:expected_records_to_build_type_2) { records_context_2.class }
+      let(:expected_records_to_build_type_3) { records_context_3.class }
+
+      let(:type_mapper) do
+        {
+          record_type_1 => [target_builder_1, target_factory_1, expected_records_to_build_type_1],
+          record_type_2 => [target_builder_2, target_factory_2, expected_records_to_build_type_2],
+          record_type_3 => [target_builder_3, target_factory_3, expected_records_to_build_type_3]
+        }
+      end
+
+      let(:records_to_build) do
+        {
+          target_domain_1 => {
+            record_type_1 => records_context_1,
+            record_type_2 => records_context_2
+          },
+          target_domain_2 => {
+            record_type_3 => records_context_3
+          }
+        }
+      end
+
+      it 'returns dictionary with coerced records' do
+        expect(target_builder_1).to receive(:call).with(target_factory_1, records_context_1).and_return(builder_result_1)
+        expect(target_builder_2).to receive(:call).with(target_factory_2, records_context_2).and_return(builder_result_2)
+        expect(target_builder_3).to receive(:call).with(target_factory_3, records_context_3).and_return(builder_result_3)
+        expect(records_dictionary_builder).to eq(
+          {
+            target_domain_1 => {
+              record_type_1 => builder_result_1,
+              record_type_2 => builder_result_2
+            },
+            target_domain_2 => {
+              record_type_3 => builder_result_3
+            }
+          }
+        )
+      end
+    end
+
+    describe 'Failure' do
+      let(:record_type) { :record_type }
+      let(:current_records_context_to_build) { 'record_context' }
+      let(:expected_records_to_build_type) { ::Array }
+      let(:type_mapper) { { record_type => ['target_builder', 'target_factory', expected_records_to_build_type] } }
+      let(:target_domain) { Faker::Internet.domain_name }
+
+      context 'when invalid record type is defined' do
+        let(:another_record_type) { :"another_#{record_type}" }
+        let(:records_to_build) { { target_domain => { another_record_type => current_records_context_to_build } } }
+
+        it do
+          expect { records_dictionary_builder }
+            .to raise_error(DnsMock::RecordTypeError, "#{another_record_type} is invalid record type")
+        end
+      end
+
+      context 'when invalid record context type defined' do
+        let(:records_to_build) { { target_domain => { record_type => current_records_context_to_build } } }
+
+        it do
+          expect { records_dictionary_builder }
+            .to raise_error(
+              DnsMock::RecordContextTypeError,
+              "#{current_records_context_to_build.class} is invalid " \
+              "record context type for #{record_type.upcase} record. " \
+              "Should be a #{expected_records_to_build_type}"
+            )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Final part of user input processing.

- [x] Implemented `DnsMock::RecordsDictionaryBuilder`
- [x] Added `Error` helper module
- [x] Changed `AVAILABLE_DNS_RECORD_TYPES` namespace
- [x] Refactored `DnsMock::RecordContextTypeError`

DSL example:

```ruby
DnsMock::RecordsDictionaryBuilder.call(
  {
    'example.com' => {
      a: %w[1.2.3.4],
      aaaa: %w[2a00:1450:4001:81e::200e],
      ns: %w[ns1.domain.com ns2.domain.com],
      mx: %w[mx1.domain.com mx2.domain.com],
      txt: %w[txt_record_1 txt_record_2],
      cname: 'some.domain.com',
      soa: [
        {
          mname: 'dns1.domain.com',
          rname: 'dns2.domain.com',
          serial: 2_035_971_683,
          refresh: 10_000,
          retry: 2_400,
          expire: 604_800,
          minimum: 3_600
        }
      ]
    }
  }
)

# =>

{"example.com"=>
  {:a=>[#<Resolv::DNS::Resource::IN::A:0x00007fa7c5d2fba8 @address=#<Resolv::IPv4 1.2.3.4>>],
   :aaaa=>[#<Resolv::DNS::Resource::IN::AAAA:0x00007fa7c5d2f8d8 @address=#<Resolv::IPv6 2A00:1450:4001:81E::200E>>],
   :ns=>[#<Resolv::DNS::Resource::IN::NS:0x00007fa7c5d2ee60 @name=#<Resolv::DNS::Name: ns1.domain.com>>, #<Resolv::DNS::Resource::IN::NS:0x00007fa7c5d2e9b0 @name=#<Resolv::DNS::Name: ns2.domain.com>>],
   :mx=>[#<Resolv::DNS::Resource::IN::MX:0x00007fa7c5d2e3c0 @exchange=#<Resolv::DNS::Name: mx1.domain.com>, @preference=10>, #<Resolv::DNS::Resource::IN::MX:0x00007fa7c5d2dee8 @exchange=#<Resolv::DNS::Name: mx2.domain.com>, @preference=20>],
   :txt=>[#<Resolv::DNS::Resource::IN::TXT:0x00007fa7c5d2dd80 @strings=["txt_record_1"]>, #<Resolv::DNS::Resource::IN::TXT:0x00007fa7c5d2dc40 @strings=["txt_record_2"]>],
   :cname=>[#<Resolv::DNS::Resource::IN::CNAME:0x00007fa7c5d2d6a0 @name=#<Resolv::DNS::Name: some.domain.com>>],
   :soa=>[#<Resolv::DNS::Resource::IN::SOA:0x00007fa7c5d2d510 @expire=604800, @minimum=3600, @mname="dns1.domain.com", @refresh=10000, @retry=2400, @rname="dns2.domain.com", @serial=2035971683>]}}
```