### PR TITLE
Feature/Implement DNS response answer

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -9,6 +9,8 @@ detectors:
   UtilityFunction:
     exclude:
       - DnsMock::RecordsDictionaryBuilder#build_records_instances_by_type
+      - DnsMock::RecordsDictionaryHelper#hostname_records_by_type
+      - DnsMock::RecordsDictionaryHelper#random_hostname
 
   ControlParameter:
     exclude:

--- a/lib/dns_mock/core.rb
+++ b/lib/dns_mock/core.rb
@@ -25,6 +25,12 @@ module DnsMock
     end
   end
 
+  RecordNotFoundError = Class.new(StandardError) do
+    def initialize(record_type, hostname)
+      super("#{record_type} not found for #{hostname} in predefined records dictionary")
+    end
+  end
+
   module Helper
     require_relative '../dns_mock/helper/error'
   end
@@ -53,6 +59,10 @@ module DnsMock
       require_relative '../dns_mock/record/builder/soa'
       require_relative '../dns_mock/record/builder/txt'
     end
+  end
+
+  module Response
+    require_relative '../dns_mock/response/answer'
   end
 
   require_relative '../dns_mock/version'

--- a/lib/dns_mock/response/answer.rb
+++ b/lib/dns_mock/response/answer.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Response
+    class Answer
+      require 'resolv'
+
+      TTL = 1
+      REVERSE_TYPE_MAPPER = DnsMock::AVAILABLE_DNS_RECORD_TYPES.each_with_object({}) do |record_type, hash|
+        hash[Resolv::DNS::Resource::IN.const_get(record_type.upcase)] = record_type
+      end.freeze
+
+      def initialize(records)
+        @records = records
+      end
+
+      def build(hostname, record_class)
+        @hostname = hostname
+        record_by_type(record_class).map { |record| [hostname, DnsMock::Response::Answer::TTL, record] }
+      end
+
+      private
+
+      attr_reader :records, :hostname
+
+      def record_by_type(record_class)
+        record_type = DnsMock::Response::Answer::REVERSE_TYPE_MAPPER[record_class]
+        found_records = records.dig(hostname.to_s, record_type)
+        raise DnsMock::RecordNotFoundError.new(record_type, hostname) unless found_records
+        found_records
+      end
+    end
+  end
+end

--- a/spec/dns_mock/core_spec.rb
+++ b/spec/dns_mock/core_spec.rb
@@ -29,3 +29,11 @@ RSpec.describe DnsMock::RecordContextTypeError do
 
   it_behaves_like 'customized error'
 end
+
+RSpec.describe DnsMock::RecordNotFoundError do
+  subject(:error_instance) { described_class.new('record_type', 'hostname') }
+
+  let(:error_context) { 'record_type not found for hostname in predefined records dictionary' }
+
+  it_behaves_like 'customized error'
+end

--- a/spec/dns_mock/response/answer_spec.rb
+++ b/spec/dns_mock/response/answer_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Response::Answer do
+  describe 'defined constants' do
+    it { expect(described_class).to be_const_defined(:TTL) }
+    it { expect(described_class).to be_const_defined(:REVERSE_TYPE_MAPPER) }
+  end
+
+  describe '#build' do
+    subject(:dns_answer) { described_class.new(records).build(hostname, record_class) }
+
+    let(:record_type) { :txt }
+    let(:records) { create_records_dictionary(hostname, record_type) }
+    let(:hostname) { Resolv::DNS::Name.create(Faker::Internet.domain_name) }
+    let(:record_class) { Resolv::DNS::Resource::IN::TXT }
+
+    context 'when hostname record found in records dictionary' do
+      it 'returns array of arrays with answers' do
+        records_by_type = hostname_records_by_type(records, hostname, record_type)
+        first_dns_record, second_dns_record = records_by_type
+        expect(dns_answer.size).to eq(records_by_type.size)
+        expect(dns_answer).to eq(
+          [
+            [hostname, DnsMock::Response::Answer::TTL, first_dns_record],
+            [hostname, DnsMock::Response::Answer::TTL, second_dns_record]
+          ]
+        )
+      end
+    end
+
+    context 'when hostname record not found in records dictionary' do
+      let(:records) do
+        create_records_dictionary(
+          Resolv::DNS::Name.create(Faker::Internet.domain_name),
+          record_type
+        )
+      end
+
+      it do
+        expect { dns_answer }.to raise_error(
+          DnsMock::RecordNotFoundError,
+          "#{record_type} not found for #{hostname} in predefined records dictionary"
+        )
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,5 +19,7 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   config.order = :random
 
+  config.include DnsMock::RecordsDictionaryHelper
+
   Kernel.srand(config.seed)
 end

--- a/spec/support/helpers/records_dictionary_helper.rb
+++ b/spec/support/helpers/records_dictionary_helper.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module RecordsDictionaryHelper
+    def create_records_dictionary(hostname, *options) # rubocop:disable Metrics/MethodLength)
+      DnsMock::RecordsDictionaryBuilder.call(
+        {
+          hostname.to_s => {
+            a: [Faker::Internet.ip_v4_address],
+            aaaa: [Faker::Internet.ip_v6_address],
+            ns: [random_hostname],
+            mx: [random_hostname],
+            txt: %w[txt_record_1 txt_record_2],
+            cname: random_hostname,
+            soa: [
+              {
+                mname: random_hostname,
+                rname: random_hostname,
+                serial: 2_035_971_683,
+                refresh: 10_000,
+                retry: 2_400,
+                expire: 604_800,
+                minimum: 3_600
+              }
+            ]
+          }.slice(*(options.empty? ? DnsMock::AVAILABLE_DNS_RECORD_TYPES : options))
+        }
+      )
+    end
+
+    def hostname_records_by_type(records, hostname, record_type)
+      records[hostname.to_s][record_type]
+    end
+
+    private
+
+    def random_hostname
+      Faker::Internet.ip_v4_address
+    end
+  end
+end

--- a/spec/support/helpers/records_dictionary_helper_spec.rb
+++ b/spec/support/helpers/records_dictionary_helper_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::RecordsDictionaryHelper, type: :helper do # rubocop:disable RSpec/FilePath
+  describe '#create_records_dictionary' do
+    subject(:records_dictionary) { create_records_dictionary(hostname, *options) }
+
+    let(:hostname) { Faker::Internet.domain_name }
+    let(:options) { [] }
+
+    context 'with Resolv::DNS::Name instance as hostname' do
+      let(:hostname) { Resolv::DNS::Name.create(Faker::Internet.domain_name) }
+
+      it 'converts Resolv::DNS::Name instance to string' do
+        expect(records_dictionary).to include(hostname.to_s)
+      end
+    end
+
+    context 'with default options' do
+      it 'has hostname as key' do
+        expect(records_dictionary).to include(hostname)
+      end
+
+      it 'has DnsMock::AVAILABLE_DNS_RECORD_TYPES as nested key values' do
+        expect(records_dictionary[hostname].keys).to include(*DnsMock::AVAILABLE_DNS_RECORD_TYPES)
+      end
+    end
+
+    context 'with custom options' do
+      let(:options) { %i[a aaaa] }
+
+      it 'has hostname as key' do
+        expect(records_dictionary).to include(hostname)
+      end
+
+      it 'has DnsMock::AVAILABLE_DNS_RECORD_TYPES as nested key values' do
+        expect(records_dictionary[hostname].keys).to include(*options)
+      end
+    end
+  end
+
+  describe '#hostname_records_by_type' do
+    let(:hostname) { Faker::Internet.domain_name }
+    let(:record_type) { :a }
+    let(:records_instances) { %i[a b] }
+    let(:records) { { hostname => { record_type => records_instances } } }
+
+    it 'returns array of hostname dns records instances by type' do
+      expect(hostname_records_by_type(records, hostname, record_type)).to eq(records_instances)
+    end
+  end
+end


### PR DESCRIPTION
The first part of DNS response:

- [x] Implemented `DnsMock::Response::Answer`
- [x] Implemented `Dns::RecordNotFoundError`
- [x] Added `DnsMock::RecordsDictionaryHelper`