### PR TITLE
Feature/Implement RandomAvailablePort service

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -14,7 +14,14 @@ detectors:
       - DnsMock::ContextGeneratorHelper#random_dns_record_type
       - DnsMock::ContextGeneratorHelper#random_hostname
       - DnsMock::ContextGeneratorHelper#create_dns_name
+      - DnsMock::ContextGeneratorHelper#random_ip_v4_address
+      - DnsMock::ContextGeneratorHelper#random_ip_v6_address
+      - DnsMock::ContextGeneratorHelper#random_txt_record_context
 
   ControlParameter:
     exclude:
       - DnsMock::Helper::Error#raise_record_type_error
+
+  MissingSafeMethod:
+    exclude:
+      - DnsMock::PortInUseHelper::TransportService

--- a/lib/dns_mock/core.rb
+++ b/lib/dns_mock/core.rb
@@ -1,27 +1,30 @@
 # frozen_string_literal: true
 
+require 'resolv'
+require 'socket'
+
 module DnsMock
   AVAILABLE_DNS_RECORD_TYPES = %i[a aaaa cname mx ns soa txt].freeze
 
-  ArgumentTypeError = Class.new(StandardError) do
+  ArgumentTypeError = ::Class.new(::StandardError) do
     def initialize(argument_class)
       super("Argument class is a #{argument_class}. Should be a Hash")
     end
   end
 
-  RecordTypeError = Class.new(StandardError) do
-    def initialize(record_type)
-      super("#{record_type} is invalid record type")
+  RandomFreePortError = ::Class.new(::RuntimeError) do
+    def initialize(attempts)
+      super("Impossible to find free random port in #{attempts} attempts")
     end
   end
 
-  RecordContextError = Class.new(StandardError) do
+  RecordContextError = ::Class.new(::StandardError) do
     def initialize(record_context, record_type)
       super("#{record_context}. Invalid #{record_type} record context")
     end
   end
 
-  RecordContextTypeError = Class.new(StandardError) do
+  RecordContextTypeError = ::Class.new(::StandardError) do
     def initialize(record_context_type, record_type, expected_record_context_type)
       super(
         "#{record_context_type} is invalid record context type for " \
@@ -31,9 +34,15 @@ module DnsMock
     end
   end
 
-  RecordNotFoundError = Class.new(StandardError) do
+  RecordNotFoundError = ::Class.new(::StandardError) do
     def initialize(record_type, hostname)
       super("#{record_type} not found for #{hostname} in predefined records dictionary")
+    end
+  end
+
+  RecordTypeError = ::Class.new(::StandardError) do
+    def initialize(record_type)
+      super("#{record_type} is invalid record type")
     end
   end
 
@@ -74,4 +83,5 @@ module DnsMock
 
   require_relative '../dns_mock/version'
   require_relative '../dns_mock/server/records_dictionary_builder'
+  require_relative '../dns_mock/server/random_available_port'
 end

--- a/lib/dns_mock/record/builder/a.rb
+++ b/lib/dns_mock/record/builder/a.rb
@@ -3,7 +3,7 @@
 module DnsMock
   module Record
     module Builder
-      A = Class.new(DnsMock::Record::Builder::Base)
+      A = ::Class.new(DnsMock::Record::Builder::Base)
     end
   end
 end

--- a/lib/dns_mock/record/builder/aaaa.rb
+++ b/lib/dns_mock/record/builder/aaaa.rb
@@ -3,7 +3,7 @@
 module DnsMock
   module Record
     module Builder
-      Aaaa = Class.new(DnsMock::Record::Builder::Base)
+      Aaaa = ::Class.new(DnsMock::Record::Builder::Base)
     end
   end
 end

--- a/lib/dns_mock/record/builder/cname.rb
+++ b/lib/dns_mock/record/builder/cname.rb
@@ -3,7 +3,7 @@
 module DnsMock
   module Record
     module Builder
-      Cname = Class.new(DnsMock::Record::Builder::Base) do
+      Cname = ::Class.new(DnsMock::Record::Builder::Base) do
         def build
           [target_factory.new(record_data: records_data).create]
         end

--- a/lib/dns_mock/record/builder/ns.rb
+++ b/lib/dns_mock/record/builder/ns.rb
@@ -3,7 +3,7 @@
 module DnsMock
   module Record
     module Builder
-      Ns = Class.new(DnsMock::Record::Builder::Base)
+      Ns = ::Class.new(DnsMock::Record::Builder::Base)
     end
   end
 end

--- a/lib/dns_mock/record/builder/txt.rb
+++ b/lib/dns_mock/record/builder/txt.rb
@@ -3,7 +3,7 @@
 module DnsMock
   module Record
     module Builder
-      Txt = Class.new(DnsMock::Record::Builder::Base)
+      Txt = ::Class.new(DnsMock::Record::Builder::Base)
     end
   end
 end

--- a/lib/dns_mock/record/factory/a.rb
+++ b/lib/dns_mock/record/factory/a.rb
@@ -3,7 +3,7 @@
 module DnsMock
   module Record
     module Factory
-      A = Class.new(DnsMock::Record::Factory::Base) do
+      A = ::Class.new(DnsMock::Record::Factory::Base) do
         record_type :a
 
         def instance_params

--- a/lib/dns_mock/record/factory/aaaa.rb
+++ b/lib/dns_mock/record/factory/aaaa.rb
@@ -3,7 +3,7 @@
 module DnsMock
   module Record
     module Factory
-      Aaaa = Class.new(DnsMock::Record::Factory::Base) do
+      Aaaa = ::Class.new(DnsMock::Record::Factory::Base) do
         record_type :aaaa
 
         def instance_params

--- a/lib/dns_mock/record/factory/base.rb
+++ b/lib/dns_mock/record/factory/base.rb
@@ -4,14 +4,13 @@ module DnsMock
   module Record
     module Factory
       class Base
-        require 'resolv'
         extend DnsMock::Helper::Error
 
         class << self
           attr_reader :target_class
 
           def record_type(record_type)
-            @target_class = Resolv::DNS::Resource::IN.const_get(
+            @target_class = ::Resolv::DNS::Resource::IN.const_get(
               record_type_check(record_type).upcase
             )
           end
@@ -24,7 +23,7 @@ module DnsMock
           end
         end
 
-        def initialize(dns_name = Resolv::DNS::Name, record_data:)
+        def initialize(dns_name = ::Resolv::DNS::Name, record_data:)
           @dns_name = dns_name
           @record_data = record_data
         end
@@ -46,7 +45,7 @@ module DnsMock
         end
 
         def create_dns_name(hostname)
-          raise ArgumentError, "cannot interpret as DNS name: #{hostname}" unless hostname.is_a?(::String)
+          raise ::ArgumentError, "cannot interpret as DNS name: #{hostname}" unless hostname.is_a?(::String)
           dns_name.create("#{hostname}.")
         end
       end

--- a/lib/dns_mock/record/factory/cname.rb
+++ b/lib/dns_mock/record/factory/cname.rb
@@ -3,7 +3,7 @@
 module DnsMock
   module Record
     module Factory
-      Cname = Class.new(DnsMock::Record::Factory::Base) do
+      Cname = ::Class.new(DnsMock::Record::Factory::Base) do
         record_type :cname
 
         def instance_params

--- a/lib/dns_mock/record/factory/mx.rb
+++ b/lib/dns_mock/record/factory/mx.rb
@@ -3,7 +3,7 @@
 module DnsMock
   module Record
     module Factory
-      Mx = Class.new(DnsMock::Record::Factory::Base) do
+      Mx = ::Class.new(DnsMock::Record::Factory::Base) do
         record_type :mx
 
         def instance_params

--- a/lib/dns_mock/record/factory/ns.rb
+++ b/lib/dns_mock/record/factory/ns.rb
@@ -3,7 +3,7 @@
 module DnsMock
   module Record
     module Factory
-      Ns = Class.new(DnsMock::Record::Factory::Base) do
+      Ns = ::Class.new(DnsMock::Record::Factory::Base) do
         record_type :ns
 
         def instance_params

--- a/lib/dns_mock/record/factory/soa.rb
+++ b/lib/dns_mock/record/factory/soa.rb
@@ -3,7 +3,7 @@
 module DnsMock
   module Record
     module Factory
-      Soa = Class.new(DnsMock::Record::Factory::Base) do
+      Soa = ::Class.new(DnsMock::Record::Factory::Base) do
         record_type :soa
 
         def instance_params

--- a/lib/dns_mock/record/factory/txt.rb
+++ b/lib/dns_mock/record/factory/txt.rb
@@ -3,7 +3,7 @@
 module DnsMock
   module Record
     module Factory
-      Txt = Class.new(DnsMock::Record::Factory::Base) do
+      Txt = ::Class.new(DnsMock::Record::Factory::Base) do
         record_type :txt
 
         def instance_params

--- a/lib/dns_mock/response/answer.rb
+++ b/lib/dns_mock/response/answer.rb
@@ -3,11 +3,9 @@
 module DnsMock
   module Response
     class Answer
-      require 'resolv'
-
       TTL = 1
       REVERSE_TYPE_MAPPER = DnsMock::AVAILABLE_DNS_RECORD_TYPES.each_with_object({}) do |record_type, hash|
-        hash[Resolv::DNS::Resource::IN.const_get(record_type.upcase)] = record_type
+        hash[::Resolv::DNS::Resource::IN.const_get(record_type.upcase)] = record_type
       end.freeze
 
       def initialize(records)

--- a/lib/dns_mock/response/message.rb
+++ b/lib/dns_mock/response/message.rb
@@ -3,9 +3,7 @@
 module DnsMock
   module Response
     class Message
-      require 'resolv'
-
-      def initialize(packet, records, dns_answer = DnsMock::Response::Answer, dns_message = Resolv::DNS::Message)
+      def initialize(packet, records, dns_answer = DnsMock::Response::Answer, dns_message = ::Resolv::DNS::Message)
         @dns_answer = dns_answer.new(records)
         @dns_message = dns_message.decode(packet)
       end

--- a/lib/dns_mock/server/random_available_port.rb
+++ b/lib/dns_mock/server/random_available_port.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module DnsMock
+  class Server
+    CURRENT_HOST_NAME = 'localhost'
+    CURRENT_HOST_ADDRESS = '127.0.0.1'
+
+    class RandomAvailablePort
+      ATTEMPTS = 100
+      MIN_DYNAMIC_PORT_NUMBER = 49_152
+      MAX_DYNAMIC_PORT_NUMBER = 65_535
+
+      class << self
+        def call
+          DnsMock::Server::RandomAvailablePort::ATTEMPTS.times do
+            port = rand(
+              DnsMock::Server::RandomAvailablePort::MIN_DYNAMIC_PORT_NUMBER..DnsMock::Server::RandomAvailablePort::MAX_DYNAMIC_PORT_NUMBER
+            )
+            return port if port_free?(port)
+          end
+          raise DnsMock::RandomFreePortError, DnsMock::Server::RandomAvailablePort::ATTEMPTS
+        end
+
+        private
+
+        def udp_port_free?(port, socket = ::UDPSocket.new)
+          socket.bind(DnsMock::Server::CURRENT_HOST_NAME, port)
+          socket.close
+          true
+        rescue ::Errno::EADDRINUSE
+          false
+        end
+
+        def tcp_port_free?(port, socket = ::Socket.new(::Socket::AF_INET, ::Socket::SOCK_STREAM, 0))
+          socket.bind(::Socket.sockaddr_in(port, DnsMock::Server::CURRENT_HOST_ADDRESS))
+          socket.close
+          true
+        rescue ::Errno::EADDRINUSE
+          false
+        end
+
+        def port_free?(port)
+          udp_port_free?(port) && tcp_port_free?(port)
+        end
+      end
+    end
+  end
+end

--- a/spec/dns_mock/core_spec.rb
+++ b/spec/dns_mock/core_spec.rb
@@ -6,20 +6,20 @@ RSpec.describe DnsMock do
   end
 end
 
+RSpec.describe DnsMock::RandomFreePortError do
+  subject(:error_instance) { described_class.new(42) }
+
+  it { expect(described_class).to be < ::RuntimeError }
+  it { expect(error_instance).to be_an_instance_of(described_class) }
+  it { expect(error_instance.to_s).to eq('Impossible to find free random port in 42 attempts') }
+end
+
 RSpec.describe DnsMock::ArgumentTypeError do
   subject(:error_instance) { described_class.new('SomeClassName') }
 
   let(:error_context) { 'Argument class is a SomeClassName. Should be a Hash' }
 
-  it_behaves_like 'customized error'
-end
-
-RSpec.describe DnsMock::RecordTypeError do
-  subject(:error_instance) { described_class.new('record_type') }
-
-  let(:error_context) { 'record_type is invalid record type' }
-
-  it_behaves_like 'customized error'
+  it_behaves_like 'customized standard error'
 end
 
 RSpec.describe DnsMock::RecordContextError do
@@ -27,7 +27,7 @@ RSpec.describe DnsMock::RecordContextError do
 
   let(:error_context) { 'record_data. Invalid record_type record context' }
 
-  it_behaves_like 'customized error'
+  it_behaves_like 'customized standard error'
 end
 
 RSpec.describe DnsMock::RecordContextTypeError do
@@ -35,7 +35,7 @@ RSpec.describe DnsMock::RecordContextTypeError do
 
   let(:error_context) { 'record_context_type is invalid record context type for record_type record. Should be a expected_type' }
 
-  it_behaves_like 'customized error'
+  it_behaves_like 'customized standard error'
 end
 
 RSpec.describe DnsMock::RecordNotFoundError do
@@ -43,5 +43,13 @@ RSpec.describe DnsMock::RecordNotFoundError do
 
   let(:error_context) { 'record_type not found for hostname in predefined records dictionary' }
 
-  it_behaves_like 'customized error'
+  it_behaves_like 'customized standard error'
+end
+
+RSpec.describe DnsMock::RecordTypeError do
+  subject(:error_instance) { described_class.new('record_type') }
+
+  let(:error_context) { 'record_type is invalid record type' }
+
+  it_behaves_like 'customized standard error'
 end

--- a/spec/dns_mock/record/builder/mx_spec.rb
+++ b/spec/dns_mock/record/builder/mx_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe DnsMock::Record::Builder::Mx do
           .with(record_data: [record_preference, record_data])
           .and_return(target_factory_instance)
       end
-      expect(builder).to eq(Array.new(records_data.size) { target_class_instance })
+      expect(builder).to eq(::Array.new(records_data.size) { target_class_instance })
     end
   end
 end

--- a/spec/dns_mock/record/builder/soa_spec.rb
+++ b/spec/dns_mock/record/builder/soa_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe DnsMock::Record::Builder::Soa do
           .with(record_data: record_data.values)
           .and_return(target_factory_instance)
       end
-      expect(builder).to eq(Array.new(records_data.size) { target_class_instance })
+      expect(builder).to eq(::Array.new(records_data.size) { target_class_instance })
     end
   end
 end

--- a/spec/dns_mock/record/factory/a_spec.rb
+++ b/spec/dns_mock/record/factory/a_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DnsMock::Record::Factory::A do
     subject(:create_factory) { described_class.new(record_data: record_data).create }
 
     context 'when valid record context' do
-      let(:record_data) { Faker::Internet.ip_v4_address }
+      let(:record_data) { random_ip_v4_address }
 
       it 'returns instance of target class' do
         expect(create_factory).to be_an_instance_of(described_class.target_class)

--- a/spec/dns_mock/record/factory/aaaa_spec.rb
+++ b/spec/dns_mock/record/factory/aaaa_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DnsMock::Record::Factory::Aaaa do
     subject(:create_factory) { described_class.new(record_data: record_data).create }
 
     context 'when valid record context' do
-      let(:record_data) { Faker::Internet.ip_v6_address }
+      let(:record_data) { random_ip_v6_address }
 
       it 'returns instance of target class' do
         expect(create_factory).to be_an_instance_of(described_class.target_class)

--- a/spec/dns_mock/record/factory/base_spec.rb
+++ b/spec/dns_mock/record/factory/base_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DnsMock::Record::Factory::Base do
   describe '.record_type' do
-    subject(:record_type) { Class.new(described_class).record_type(defined_record_type) }
+    subject(:record_type) { ::Class.new(described_class).record_type(defined_record_type) }
 
     context 'when invalid record type' do
       let(:defined_record_type) { :invalid_record_type }

--- a/spec/dns_mock/record/factory/soa_spec.rb
+++ b/spec/dns_mock/record/factory/soa_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DnsMock::Record::Factory::Soa do
   describe '#instance_params' do
     subject(:instance_params) { described_class.new(record_data: record_data).instance_params }
 
-    let(:dns_names) { Array.new(2) { random_hostname } }
+    let(:dns_names) { ::Array.new(2) { random_hostname } }
     let(:int_params) { (0..5).to_a }
     let(:record_data) { dns_names + int_params }
     let(:expected_data) do

--- a/spec/dns_mock/record/factory/txt_spec.rb
+++ b/spec/dns_mock/record/factory/txt_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe DnsMock::Record::Factory::Txt do
   describe '#create' do
     subject(:create_factory) { described_class.new(record_data: record_data).create }
 
-    let(:record_data) { Faker::Internet.uuid }
+    let(:record_data) { random_txt_record_context }
 
     it 'returns instance of target class' do
       expect(create_factory).to be_an_instance_of(described_class.target_class)

--- a/spec/dns_mock/response/answer_spec.rb
+++ b/spec/dns_mock/response/answer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DnsMock::Response::Answer do
     subject(:dns_answer) { described_class.new(records).build(hostname, record_class) }
 
     let(:records) { create_records_dictionary(hostname, record_type) }
-    let(:hostname) { Resolv::DNS::Name.create(random_hostname) }
+    let(:hostname) { ::Resolv::DNS::Name.create(random_hostname) }
 
     context 'when hostname record found in records dictionary' do
       DnsMock::Response::Answer::REVERSE_TYPE_MAPPER.each do |r_class, r_type|
@@ -22,7 +22,7 @@ RSpec.describe DnsMock::Response::Answer do
             records_by_type = hostname_records_by_type(records, hostname, record_type)
             expect(dns_answer.size).to eq(records_by_type.size)
             expect(dns_answer).to eq(
-              Array.new(records_by_type.size).map.with_index do |_, index|
+              ::Array.new(records_by_type.size).map.with_index do |_, index|
                 [hostname, DnsMock::Response::Answer::TTL, records_by_type[index]]
               end
             )
@@ -33,13 +33,8 @@ RSpec.describe DnsMock::Response::Answer do
 
     context 'when hostname record not found in records dictionary' do
       let(:record_type) { :a }
-      let(:record_class) { Resolv::DNS::Resource::IN::A }
-      let(:records) do
-        create_records_dictionary(
-          Resolv::DNS::Name.create(random_hostname),
-          record_type
-        )
-      end
+      let(:record_class) { ::Resolv::DNS::Resource::IN::A }
+      let(:records) { create_records_dictionary(random_hostname, record_type) }
 
       it do
         expect { dns_answer }.to raise_error(

--- a/spec/dns_mock/server/random_available_port_spec.rb
+++ b/spec/dns_mock/server/random_available_port_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Server do
+  describe 'defined constants' do
+    it { expect(described_class).to be_const_defined(:CURRENT_HOST_NAME) }
+    it { expect(described_class).to be_const_defined(:CURRENT_HOST_ADDRESS) }
+  end
+end
+
+RSpec.describe DnsMock::Server::RandomAvailablePort do
+  describe 'defined constants' do
+    it { expect(described_class).to be_const_defined(:ATTEMPTS) }
+    it { expect(described_class).to be_const_defined(:MIN_DYNAMIC_PORT_NUMBER) }
+    it { expect(described_class).to be_const_defined(:MAX_DYNAMIC_PORT_NUMBER) }
+  end
+
+  describe '.call' do
+    subject(:random_available_port) { described_class.call }
+
+    let(:min_dynamic_port_number) { 49_998 }
+    let(:max_dynamic_port_number) { 49_999 }
+
+    before do
+      stub_const('DnsMock::Server::RandomAvailablePort::MIN_DYNAMIC_PORT_NUMBER', min_dynamic_port_number)
+      stub_const('DnsMock::Server::RandomAvailablePort::MAX_DYNAMIC_PORT_NUMBER', max_dynamic_port_number)
+    end
+
+    context 'when udp port is busy' do
+      let(:busy_udp_port_number) { min_dynamic_port_number }
+      let(:free_port_number) { max_dynamic_port_number }
+
+      before { udp_service(busy_udp_port_number).bind! }
+
+      after { udp_service.unbind! }
+
+      include_examples 'random free upd & tcp port'
+    end
+
+    context 'when tcp port is busy' do
+      let(:busy_tcp_port_number) { min_dynamic_port_number }
+      let(:free_port_number) { max_dynamic_port_number }
+
+      before { tcp_service(busy_tcp_port_number).bind! }
+
+      after { tcp_service.unbind! }
+
+      include_examples 'random free upd & tcp port'
+    end
+
+    context 'when both udp and tcp port are free' do
+      let(:min_dynamic_port_number) { 49_997 }
+      let(:busy_udp_port_number) { min_dynamic_port_number }
+      let(:busy_tcp_port_number) { min_dynamic_port_number.next }
+      let(:free_port_number) { max_dynamic_port_number }
+
+      before do
+        udp_service(busy_udp_port_number).bind!
+        tcp_service(busy_tcp_port_number).bind!
+      end
+
+      after do
+        udp_service.unbind!
+        tcp_service.unbind!
+      end
+
+      include_examples 'random free upd & tcp port'
+    end
+
+    context 'when random free port not found' do
+      let(:attempts) { 1 }
+      let(:max_dynamic_port_number) { 49_998 }
+      let(:busy_port_number) { min_dynamic_port_number }
+
+      before do
+        stub_const('DnsMock::Server::RandomAvailablePort::ATTEMPTS', attempts)
+        udp_service(busy_port_number).bind!
+      end
+
+      after { udp_service.unbind! }
+
+      it do
+        expect { random_available_port }
+          .to raise_error(
+            DnsMock::RandomFreePortError,
+            "Impossible to find free random port in #{attempts} attempts"
+          )
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 rspec_custom = File.join(File.dirname(__FILE__), 'support/**/*.rb')
 Dir[File.expand_path(rspec_custom)].sort.each { |file| require file unless file[/\A.+_spec\.rb\z/] }
 
-require 'dns_mock'
+require_relative '../lib/dns_mock'
 
 RSpec.configure do |config|
   config.expect_with(:rspec) do |expectations|
@@ -22,6 +22,7 @@ RSpec.configure do |config|
   config.include DnsMock::ContextGeneratorHelper
   config.include DnsMock::RecordsDictionaryHelper
   config.include DnsMock::DnsMessageHelper
+  config.include DnsMock::PortInUseHelper
 
-  Kernel.srand(config.seed)
+  ::Kernel.srand(config.seed)
 end

--- a/spec/support/helpers/context_generator_helper.rb
+++ b/spec/support/helpers/context_generator_helper.rb
@@ -10,8 +10,20 @@ module DnsMock
       Faker::Internet.domain_name
     end
 
-    def create_dns_name(hostname, dns_name = Resolv::DNS::Name)
+    def create_dns_name(hostname, dns_name = ::Resolv::DNS::Name)
       dns_name.create("#{hostname}.")
+    end
+
+    def random_ip_v4_address
+      Faker::Internet.ip_v4_address
+    end
+
+    def random_ip_v6_address
+      Faker::Internet.ip_v6_address
+    end
+
+    def random_txt_record_context
+      Faker::Internet.uuid
     end
   end
 end

--- a/spec/support/helpers/context_generator_helper_spec.rb
+++ b/spec/support/helpers/context_generator_helper_spec.rb
@@ -26,4 +26,31 @@ RSpec.describe DnsMock::ContextGeneratorHelper, type: :helper do # rubocop:disab
       expect(helper).to eq(dns_name_instance)
     end
   end
+
+  describe '#random_ip_v4_address' do
+    subject(:helper) { random_ip_v4_address }
+
+    it 'returns random ipv4 address as String' do
+      expect(Faker::Internet).to receive(:ip_v4_address).and_call_original
+      expect(helper).to be_an_instance_of(::String)
+    end
+  end
+
+  describe '#random_ip_v6_address' do
+    subject(:helper) { random_ip_v6_address }
+
+    it 'returns random ipv6 address as String' do
+      expect(Faker::Internet).to receive(:ip_v6_address).and_call_original
+      expect(helper).to be_an_instance_of(::String)
+    end
+  end
+
+  describe '#random_txt_record_context' do
+    subject(:helper) { random_txt_record_context }
+
+    it 'returns random txt record context as String' do
+      expect(Faker::Internet).to receive(:uuid).and_call_original
+      expect(helper).to be_an_instance_of(::String)
+    end
+  end
 end

--- a/spec/support/helpers/dns_message_helper.rb
+++ b/spec/support/helpers/dns_message_helper.rb
@@ -2,7 +2,7 @@
 
 module DnsMock
   module DnsMessageHelper
-    def create_request_binary_dns_message(hostname, record_type, dns_message = Resolv::DNS::Message)
+    def create_request_binary_dns_message(hostname, record_type, dns_message = ::Resolv::DNS::Message)
       dns_message.new.tap do |message|
         message.question << [to_dns_name(hostname), dns_record_class_by_type(record_type)]
       end.encode
@@ -10,13 +10,13 @@ module DnsMock
 
     private
 
-    def to_dns_name(hostname, dns_name = Resolv::DNS::Name)
+    def to_dns_name(hostname, dns_name = ::Resolv::DNS::Name)
       dns_name.create("#{hostname}.")
     end
 
     def dns_record_class_by_type(record_type)
       raise DnsMock::RecordTypeError, record_type unless DnsMock::AVAILABLE_DNS_RECORD_TYPES.include?(record_type)
-      Resolv::DNS::Resource::IN.const_get(record_type.upcase)
+      ::Resolv::DNS::Resource::IN.const_get(record_type.upcase)
     end
   end
 end

--- a/spec/support/helpers/port_in_use_helper.rb
+++ b/spec/support/helpers/port_in_use_helper.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module PortInUseHelper
+    %i[udp_service tcp_service].each do |helper_method|
+      define_method(helper_method) do |port_number = nil|
+        target_accessor = :"current_#{helper_method}"
+        target_instance = DnsMock::PortInUseHelper.const_get(helper_method.to_s.split('_').map(&:capitalize).join).new(port_number)
+        port_number ? send(:"#{target_accessor}=", target_instance) : send(target_accessor)
+      end
+    end
+
+    private
+
+    attr_accessor :current_udp_service, :current_tcp_service
+
+    class TransportService
+      attr_reader :port, :socket
+
+      def initialize(port, socket)
+        @port = port
+        @socket = socket
+      end
+
+      def bind!
+        run
+        self.binded = true
+      end
+
+      def unbind!
+        return false unless binded
+        socket.close
+        !self.binded = false
+      end
+
+      private
+
+      attr_accessor :binded
+
+      def run; end
+    end
+
+    UdpService = ::Class.new(DnsMock::PortInUseHelper::TransportService) do
+      def initialize(port, socket = ::UDPSocket.new)
+        super
+      end
+
+      private
+
+      def run
+        socket.bind(DnsMock::Server::CURRENT_HOST_ADDRESS, port)
+      end
+    end
+
+    TcpService = ::Class.new(DnsMock::PortInUseHelper::TransportService) do
+      def initialize(port, socket = ::Socket.new(::Socket::AF_INET, ::Socket::SOCK_STREAM, 0))
+        super
+      end
+
+      def run
+        socket.bind(::Socket.sockaddr_in(port, DnsMock::Server::CURRENT_HOST_ADDRESS))
+      end
+    end
+  end
+end

--- a/spec/support/helpers/port_in_use_helper_spec.rb
+++ b/spec/support/helpers/port_in_use_helper_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::PortInUseHelper, type: :helper do # rubocop:disable RSpec/FilePath
+  let(:port_number) { 49_998 }
+
+  describe '#udp_service' do
+    context 'when port number is free' do
+      it 'has the same port number' do
+        expect(udp_service(port_number)).to be_an_instance_of(DnsMock::PortInUseHelper::UdpService)
+        expect(udp_service.port).to eq(port_number)
+      end
+
+      it 'bind/unbind port' do
+        udp_service(port_number)
+        expect(udp_service.unbind!).to be(false)
+        expect(udp_service.bind!).to be(true)
+        expect(udp_service.unbind!).to be(true)
+      end
+    end
+
+    context 'when port number is busy' do
+      it do
+        udp_service(port_number).bind!
+        expect { udp_service.bind! }
+          .to raise_error(
+            ::Errno::EINVAL,
+            "Invalid argument - bind(2) for \"#{DnsMock::Server::CURRENT_HOST_ADDRESS}\" port #{port_number}"
+          )
+        udp_service.unbind!
+      end
+    end
+  end
+
+  describe '#tcp_service' do
+    context 'when port number is free' do
+      it 'has the same port number' do
+        expect(tcp_service(port_number)).to be_an_instance_of(DnsMock::PortInUseHelper::TcpService)
+        expect(tcp_service.port).to eq(port_number)
+      end
+
+      it 'bind/unbind port' do
+        tcp_service(port_number)
+        expect(tcp_service.unbind!).to be(false)
+        expect(tcp_service.bind!).to be(true)
+        expect(tcp_service.unbind!).to be(true)
+      end
+    end
+
+    context 'when port number is busy' do
+      it do
+        tcp_service(port_number).bind!
+        expect { tcp_service.bind! }
+          .to raise_error(
+            ::Errno::EINVAL,
+            "Invalid argument - bind(2) for #{DnsMock::Server::CURRENT_HOST_ADDRESS}:#{port_number}"
+          )
+        tcp_service.unbind!
+      end
+    end
+  end
+end

--- a/spec/support/helpers/records_dictionary_helper.rb
+++ b/spec/support/helpers/records_dictionary_helper.rb
@@ -6,11 +6,11 @@ module DnsMock
       DnsMock::Server::RecordsDictionaryBuilder.call(
         {
           hostname.to_s => {
-            a: [Faker::Internet.ip_v4_address],
-            aaaa: [Faker::Internet.ip_v6_address],
+            a: [random_ip_v4_address],
+            aaaa: [random_ip_v6_address],
             ns: [random_hostname],
             mx: [random_hostname],
-            txt: %w[txt_record_1 txt_record_2],
+            txt: [random_txt_record_context],
             cname: random_hostname,
             soa: [
               {

--- a/spec/support/helpers/records_dictionary_helper_spec.rb
+++ b/spec/support/helpers/records_dictionary_helper_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DnsMock::RecordsDictionaryHelper, type: :helper do # rubocop:disa
     let(:options) { [] }
 
     context 'with Resolv::DNS::Name instance as hostname' do
-      let(:hostname) { Resolv::DNS::Name.create(random_hostname) }
+      let(:hostname) { ::Resolv::DNS::Name.create(random_hostname) }
 
       it 'converts Resolv::DNS::Name instance to string' do
         expect(records_dictionary).to include(hostname.to_s)

--- a/spec/support/matchers/have_answer_section_with.rb
+++ b/spec/support/matchers/have_answer_section_with.rb
@@ -2,8 +2,8 @@
 
 RSpec::Matchers.define(:have_answer_section_with) do |hostname, records_by_record_type|
   match do |binary_dns_message|
-    hostname = Resolv::DNS::Name.create("#{hostname}.")
-    Resolv::DNS::Message
+    hostname = ::Resolv::DNS::Name.create("#{hostname}.")
+    ::Resolv::DNS::Message
       .decode(binary_dns_message)
       .answer
       .zip(records_by_record_type)

--- a/spec/support/matchers/have_question_section_with.rb
+++ b/spec/support/matchers/have_question_section_with.rb
@@ -2,9 +2,9 @@
 
 RSpec::Matchers.define(:have_question_section_with) do |hostname, record_type|
   match do |binary_dns_message|
-    Resolv::DNS::Message.decode(binary_dns_message).question.first == [
-      Resolv::DNS::Name.create("#{hostname}."),
-      Resolv::DNS::Resource::IN.const_get(record_type.upcase)
+    ::Resolv::DNS::Message.decode(binary_dns_message).question.first == [
+      ::Resolv::DNS::Name.create("#{hostname}."),
+      ::Resolv::DNS::Resource::IN.const_get(record_type.upcase)
     ]
   end
 end

--- a/spec/support/shared_contexts/base_builder_behaviour.rb
+++ b/spec/support/shared_contexts/base_builder_behaviour.rb
@@ -23,7 +23,7 @@ module DnsMock
             .with(record_data: record_data)
             .and_return(target_factory_instance)
         end
-        expect(builder).to eq(Array.new(records_data.size) { target_class_instance })
+        expect(builder).to eq(::Array.new(records_data.size) { target_class_instance })
       end
     end
   end

--- a/spec/support/shared_examples/customized_standard_error.rb
+++ b/spec/support/shared_examples/customized_standard_error.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module DnsMock
-  RSpec.shared_examples 'customized error' do
-    it { expect(described_class).to be < StandardError }
+  RSpec.shared_examples 'customized standard error' do
+    it { expect(described_class).to be < ::StandardError }
     it { expect(error_instance).to be_an_instance_of(described_class) }
     it { expect(error_instance.to_s).to eq(error_context) }
   end

--- a/spec/support/shared_examples/random_free_upd_tcp_port.rb
+++ b/spec/support/shared_examples/random_free_upd_tcp_port.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DnsMock
+  RSpec.shared_examples 'random free upd & tcp port' do
+    it 'returns random free upd & tcp port' do
+      expect(random_available_port).to eq(free_port_number)
+    end
+  end
+end


### PR DESCRIPTION
- [x] Implemented `DnsMock::Server::RandomAvailablePort` service, tests
- [x] Refactored namespaces for native Ruby classes
- [x] Added `DnsMock::RandomFreePortError`, refactored error shared examples namespace
- [x] Added `PortInUseHelper`, tests