### PR TITLE
Feature/Ability to mock PTR records

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -20,6 +20,7 @@ detectors:
       - DnsMock::RecordsDictionaryHelper#create_records_dictionary_by_records
       - DnsMock::ServerHelper#start_random_server
       - DnsMock::ServerHelper#stop_all_running_servers
+      - DnsMock::Server::RecordsDictionaryBuilder#rdns_lookup_prefix
 
   ControlParameter:
     exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -119,7 +119,7 @@ Style/HashExcept:
   Enabled: true
 
 Layout/LineLength:
-  Max: 140
+  Max: 150
 
 Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2021-01-26
+
+### PTR record support
+
+Added ability to mock PTR records. Please note, you can define host address without RDNS lookup prefix (`.in-addr.arpa`). `DnsMock` will do it for you.
+
+```ruby
+records = {
+  '1.1.1.1' => {
+    ptr: %w[domain_1.com domain_2.com]
+  }
+}
+
+DnsMock.start_server(records: records)
+```
+
+```bash
+dig @localhost -p 5300 -x 1.1.1.1
+```
+
+```
+; <<>> DiG 9.10.6 <<>> @localhost -p 5300 -x 1.1.1.1
+; (2 servers found)
+
+;; ANSWER SECTION:
+1.1.1.1.in-addr.arpa.	1	IN	PTR	domain_1.com.
+1.1.1.1.in-addr.arpa.	1	IN	PTR	domain_2.com.
+
+;; Query time: 0 msec
+;; SERVER: 127.0.0.1#5300(127.0.0.1)
+;; WHEN: Mon Jan 25 19:58:39 EET 2021
+;; MSG SIZE  rcvd: 98
+```
+
 ## [0.1.0] - 2021-01-19
 
 ### First release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dns_mock (0.1.0)
+    dns_mock (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Usage](#usage)
+- [Contributing](#contributing)
+- [License](#license)
+- [Code of Conduct](#code-of-conduct)
+- [Credits](#credits)
+- [Versioning](#versioning)
+- [Changelog](CHANGELOG.md)
 
 ## Requirements
 
@@ -23,9 +29,11 @@ Ruby MRI 2.5.0+
 
 ## Features
 
-- Ability to mimic any DNS records for your test environment
+- Ability to mimic any DNS records (`A`, `AAAA`, `CNAME`, `MX`, `NS`, `PTR`, `SOA` and `TXT`)
 - Zero runtime dependencies
-- Test framework agnostic (`RSpec`, `Test::Unit`, `MiniTest`). Even can be used outside of test frameworks
+- Lightweight UDP DNS mock server with dynamic/manual port assignment
+- Test framework agnostic (it's PORO, so you can use it outside of `RSpec`, `Test::Unit` or `MiniTest`)
+- Simple and intuitive DSL
 
 ## Installation
 
@@ -48,10 +56,10 @@ Or install it yourself as:
 ## Usage
 
 ```ruby
-# Example of mocked DNS records
+# Example of mocked DNS records structure
 records = {
   'example.com' => {
-    a: %w[1.1.1.1, 2.2.2.2],
+    a: %w[1.1.1.1 2.2.2.2],
     aaaa: %w[2a00:1450:4001:81e::200e],
     ns: %w[ns1.domain.com ns2.domain.com],
     mx: %w[mx1.domain.com mx2.domain.com],
@@ -68,16 +76,55 @@ records = {
         minimum: 3_600
       }
     ]
+  },
+  '1.1.1.1' => {
+    ptr: %w[domain_1.com domain_2.com]
   }
 }
 
-# Main DnsMock interface:
-dns_mock_server = DnsMock.start_server(records: records) # records, port are an optional params
-dns_mock_server.port
-dns_mock_server.assign_mocks(records)
-dns_mock_server.reset_mocks!
-dns_mock_server.stop!
+# Main DnsMock interface. records:Hash, port:Integer are an
+# optional params. By default creates dns mock server with empty
+# records. A free port for server will be randomly assigned in
+# the range from 49152 to 65535. Returns current dns mock server
+dns_mock_server = DnsMock.start_server(records: records) # => DnsMock::Server instance
 
-DnsMock.running_servers
-DnsMock.stop_running_servers!
+# returns current dns mock server port
+dns_mock_server.port # => 49322
+
+# interface to setup mock records.
+# Available only in case when server mocked records is empty
+dns_mock_server.assign_mocks(records) # => true/nil
+
+# interface to reset current mocked records
+dns_mock_server.reset_mocks! # => true
+
+# interface to stop current dns mock server
+dns_mock_server.stop! # => true
+
+# returns list of running dns mock servers
+DnsMock.running_servers # => [DnsMock::Server instance]
+
+# interface to stop all running dns mock servers
+DnsMock.stop_running_servers! # => true
 ```
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/mocktools/ruby-dns-mock. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct. Please check the [open tikets](https://github.com/mocktools/ruby-dns-mock/issues). Be shure to follow Contributor Code of Conduct below and our [Contributing Guidelines](CONTRIBUTING.md).
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+
+## Code of Conduct
+
+Everyone interacting in the DnsMock project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](CODE_OF_CONDUCT.md).
+
+## Credits
+
+- [The Contributors](https://github.com/mocktools/ruby-dns-mock/graphs/contributors) for code and awesome suggestions
+- [The Stargazers](https://github.com/mocktools/ruby-dns-mock/stargazers) for showing their support
+
+## Versioning
+
+DnsMock uses [Semantic Versioning 2.0.0](https://semver.org)

--- a/lib/dns_mock/core.rb
+++ b/lib/dns_mock/core.rb
@@ -4,7 +4,7 @@ require 'resolv'
 require 'socket'
 
 module DnsMock
-  AVAILABLE_DNS_RECORD_TYPES = %i[a aaaa cname mx ns soa txt].freeze
+  AVAILABLE_DNS_RECORD_TYPES = %i[a aaaa cname mx ns ptr soa txt].freeze
 
   module Error
     require_relative '../dns_mock/error/argument_type'
@@ -26,6 +26,7 @@ module DnsMock
       require_relative '../dns_mock/record/factory/cname'
       require_relative '../dns_mock/record/factory/mx'
       require_relative '../dns_mock/record/factory/ns'
+      require_relative '../dns_mock/record/factory/ptr'
       require_relative '../dns_mock/record/factory/soa'
       require_relative '../dns_mock/record/factory/txt'
     end
@@ -39,6 +40,7 @@ module DnsMock
       require_relative '../dns_mock/record/builder/cname'
       require_relative '../dns_mock/record/builder/mx'
       require_relative '../dns_mock/record/builder/ns'
+      require_relative '../dns_mock/record/builder/ptr'
       require_relative '../dns_mock/record/builder/soa'
       require_relative '../dns_mock/record/builder/txt'
     end

--- a/lib/dns_mock/record/builder/ptr.rb
+++ b/lib/dns_mock/record/builder/ptr.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Builder
+      Ptr = ::Class.new(DnsMock::Record::Builder::Base)
+    end
+  end
+end

--- a/lib/dns_mock/record/factory/ptr.rb
+++ b/lib/dns_mock/record/factory/ptr.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Record
+    module Factory
+      Ptr = ::Class.new(DnsMock::Record::Factory::Base) do
+        record_type :ptr
+
+        def instance_params
+          [create_dns_name(record_data)]
+        end
+      end
+    end
+  end
+end

--- a/lib/dns_mock/version.rb
+++ b/lib/dns_mock/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DnsMock
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/spec/dns_mock/record/builder/ptr_spec.rb
+++ b/spec/dns_mock/record/builder/ptr_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Record::Builder::Ptr do
+  include_context 'base builder behaviour'
+end

--- a/spec/dns_mock/record/factory/ptr_spec.rb
+++ b/spec/dns_mock/record/factory/ptr_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Record::Factory::Ptr do
+  it { expect(described_class).to be < DnsMock::Record::Factory::Base }
+
+  describe '#instance_params' do
+    subject(:instance_params) { described_class.new(dns_name, record_data: record_data).instance_params }
+
+    let(:dns_name) { class_double('DnsName') }
+    let(:dns_name_instance) { instance_double('DnsName') }
+    let(:record_data) { 'some_record_context' }
+
+    it 'returns prepared target class instance params' do
+      expect(dns_name).to receive(:create).with("#{record_data}.").and_return(dns_name_instance)
+      expect(instance_params).to eq([dns_name_instance])
+    end
+  end
+
+  describe '#create' do
+    subject(:create_factory) { described_class.new(record_data: record_data).create }
+
+    context 'when valid record context' do
+      let(:record_data) { random_hostname }
+
+      it 'returns instance of target class' do
+        expect(create_factory).to be_an_instance_of(described_class.target_class)
+        expect(create_factory.name.to_s).to eq(record_data)
+      end
+    end
+
+    context 'when invalid record context' do
+      let(:record_data) { 42 }
+      let(:error_context) { "cannot interpret as DNS name: #{record_data}. Invalid PTR record context" }
+
+      it_behaves_like 'target class exception wrapper'
+    end
+  end
+end

--- a/spec/dns_mock/server/records_dictionary_builder_spec.rb
+++ b/spec/dns_mock/server/records_dictionary_builder_spec.rb
@@ -2,6 +2,8 @@
 
 RSpec.describe DnsMock::Server::RecordsDictionaryBuilder do
   describe 'defined constants' do
+    it { expect(described_class).to be_const_defined(:IP_ADDRESS_PATTERN) }
+    it { expect(described_class).to be_const_defined(:RDNS_LOOKUP_PREFIX) }
     it { expect(described_class).to be_const_defined(:TYPE_MAPPER) }
   end
 
@@ -12,7 +14,7 @@ RSpec.describe DnsMock::Server::RecordsDictionaryBuilder do
 
     describe 'Success' do
       let(:target_domain_1) { random_hostname }
-      let(:target_domain_2) { random_hostname }
+      let(:target_domain_2) { random_ip_v4_address }
       let(:record_type_1) { :record_type_1 }
       let(:record_type_2) { :record_type_2 }
       let(:record_type_3) { :record_type_3 }
@@ -62,7 +64,7 @@ RSpec.describe DnsMock::Server::RecordsDictionaryBuilder do
               record_type_1 => builder_result_1,
               record_type_2 => builder_result_2
             },
-            target_domain_2 => {
+            "#{target_domain_2}.in-addr.arpa" => {
               record_type_3 => builder_result_3
             }
           }

--- a/spec/dns_mock_spec.rb
+++ b/spec/dns_mock_spec.rb
@@ -101,6 +101,13 @@ RSpec.describe DnsMock do
         .config(**rspec_dns_config)
     end
 
+    it 'returns predefined PTR record' do
+      expect(domain).to have_dns
+        .with_type('PTR')
+        .and_domainname(records_by_domain[:ptr].first)
+        .config(**rspec_dns_config)
+    end
+
     it 'returns predefined MX record' do
       expect(domain).to have_dns
         .with_type('MX')

--- a/spec/support/helpers/context_generator_helper.rb
+++ b/spec/support/helpers/context_generator_helper.rb
@@ -34,6 +34,7 @@ module DnsMock
           a: [random_ip_v4_address],
           aaaa: [random_ip_v6_address],
           ns: [random_hostname],
+          ptr: [random_hostname],
           mx: [random_hostname],
           txt: [random_txt_record_context],
           cname: random_hostname,

--- a/spec/support/helpers/records_dictionary_helper.rb
+++ b/spec/support/helpers/records_dictionary_helper.rb
@@ -9,6 +9,7 @@ module DnsMock
             a: [random_ip_v4_address],
             aaaa: [random_ip_v6_address],
             ns: [random_hostname],
+            ptr: [random_hostname],
             mx: [random_hostname],
             txt: [random_txt_record_context],
             cname: random_hostname,


### PR DESCRIPTION
- [x] Updated `RecordsDictionaryBuilder`, tests
- [x] Added `Builder::Ptr`, tests
- [x] Added `Factory::Ptr`, tests
- [x] Updated `DnsMock` integration tests
- [x] Updated linter configs
- [x] Updated gem version, readme, changelog