### PR TITLE
Feature/Ability to specify MX record priority

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -53,3 +53,7 @@ detectors:
     exclude:
       - DnsMock::Server#initialize
       - DnsMock#start_server
+
+  NilCheck:
+    exclude:
+      - DnsMock::Record::Builder::Mx#build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2021-02-04
+
+### Ability to specify MX record priority
+
+Added ability to specify custom priority of MX record if it needed. Now it impossible to define null or backup MX records. Please note, if you haven't specified a priority of MX record, it will be assigned automatically. MX records builder is assigning priority with step 10 from first item of defined MX records array.
+
+```ruby
+records = {
+  'example.com' => {
+    mx: %w[.:0 mx1.domain.com:10 mx2.domain.com:10 mx3.domain.com]
+  }
+}
+
+DnsMock.start_server(records: records)
+```
+
+```bash
+dig @localhost -p 5300 MX example.com
+```
+
+```
+; <<>> DiG 9.10.6 <<>> @localhost -p 5300 MX example.com
+
+;; ANSWER SECTION:
+example.com.		1	IN	MX	0 .
+example.com.		1	IN	MX	10 mx1.domain.com.
+example.com.		1	IN	MX	10 mx2.domain.com.
+example.com.		1	IN	MX	40 mx3.domain.com.
+
+;; Query time: 0 msec
+;; SERVER: 127.0.0.1#5300(127.0.0.1)
+;; WHEN: Wed Feb 03 20:19:51 EET 2021
+;; MSG SIZE  rcvd: 102
+```
+
 ## [1.1.0] - 2021-02-01
 
 ### RSpec native support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dns_mock (1.1.0)
+    dns_mock (1.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ Or install it yourself as:
 ## Usage
 
 ```ruby
-# Example of mocked DNS records structure
+# Example of mocked DNS records, please follow this data structure
 records = {
   'example.com' => {
     a: %w[1.1.1.1 2.2.2.2],
     aaaa: %w[2a00:1450:4001:81e::200e],
     ns: %w[ns1.domain.com ns2.domain.com],
-    mx: %w[mx1.domain.com mx2.domain.com],
+    mx: %w[mx1.domain.com mx2.domain.com:50], # you can specify host(s) or host(s) with priority
     txt: %w[txt_record_1 txt_record_2],
     cname: 'some.domain.com',
     soa: [
@@ -132,7 +132,7 @@ require 'dns_mock/test_framework/rspec'
 
 #### DnsMock RSpec helper
 
-Just add `DnsMock::TestFramework::RSpec::Helper` if you wanna have shortcut for DnsMock server instance into your RSpec.describe blocks:
+Just add `DnsMock::TestFramework::RSpec::Helper` if you wanna use shortcut `dns_mock_server` for DnsMock server instance into your `RSpec.describe` blocks:
 
 ```ruby
 # spec/support/config/dns_mock.rb

--- a/lib/dns_mock/record/builder/mx.rb
+++ b/lib/dns_mock/record/builder/mx.rb
@@ -4,17 +4,28 @@ module DnsMock
   module Record
     module Builder
       class Mx < DnsMock::Record::Builder::Base
+        include DnsMock::Error::Helper
+
+        MX_RECORD_REGEX_PATTERN = /\A(.+):(\d+)|(.+)\z/.freeze
         RECORD_PREFERENCE_STEP = 10
 
         def build
           records_data.map.with_index(1) do |record_data, record_preference|
+            record_data, custom_record_preference = parse_mx_record_data(record_data)
             target_factory.new(
               record_data: [
-                record_preference * DnsMock::Record::Builder::Mx::RECORD_PREFERENCE_STEP,
+                custom_record_preference&.to_i || record_preference * DnsMock::Record::Builder::Mx::RECORD_PREFERENCE_STEP,
                 record_data
               ]
             ).create
           end
+        end
+
+        private
+
+        def parse_mx_record_data(record_data)
+          raise_record_context_type_error(:mx, record_data, ::String)
+          record_data.scan(DnsMock::Record::Builder::Mx::MX_RECORD_REGEX_PATTERN).flatten.compact
         end
       end
     end

--- a/lib/dns_mock/version.rb
+++ b/lib/dns_mock/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DnsMock
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end

--- a/spec/dns_mock/record/builder/mx_spec.rb
+++ b/spec/dns_mock/record/builder/mx_spec.rb
@@ -5,25 +5,69 @@ RSpec.describe DnsMock::Record::Builder::Mx do
     subject(:builder_class) { described_class }
 
     it { is_expected.to be < DnsMock::Record::Builder::Base }
+    it { is_expected.to be_const_defined(:MX_RECORD_REGEX_PATTERN) }
     it { is_expected.to be_const_defined(:RECORD_PREFERENCE_STEP) }
+  end
+
+  describe 'MX_RECORD_REGEX_PATTERN' do
+    subject(:regex_pattern) { described_class::MX_RECORD_REGEX_PATTERN }
+
+    context 'when host with priority' do
+      subject(:string) { "#{host}:#{priority}" }
+
+      let(:host) { random_hostname }
+      let(:priority) { rand(100).to_s }
+
+      it { expect(regex_pattern.match?(string)).to be(true) }
+      it { expect(string[regex_pattern, 1]).to eq(host) }
+      it { expect(string[regex_pattern, 2]).to eq(priority) }
+    end
+
+    context 'when host without priority' do
+      subject(:string) { random_hostname }
+
+      it { expect(regex_pattern.match?(string)).to be(true) }
+      it { expect(string[regex_pattern, 3]).to eq(string) }
+    end
   end
 
   describe '.call' do
     subject(:builder) { described_class.call(target_factory, records_data) }
 
     let(:target_factory) { class_double('TargetFactory') }
-    let(:target_class_instance) { instance_double('TargetClass') }
-    let(:target_factory_instance) { instance_double('TargetFactory', create: target_class_instance) }
-    let(:records_data) { (0..2) }
 
-    it 'returns array of target class instances' do
-      [10, 20, 30].zip(records_data).each do |record_preference, record_data|
-        expect(target_factory)
-          .to receive(:new)
-          .with(record_data: [record_preference, record_data])
-          .and_return(target_factory_instance)
+    describe 'Success' do
+      context 'when valid records_data nested type' do
+        let(:target_class_instance) { instance_double('TargetClass') }
+        let(:target_factory_instance) { instance_double('TargetFactory', create: target_class_instance) }
+        let(:mx_host) { random_hostname }
+        let(:mx_priority) { 0 }
+        let(:records_data) { ["#{mx_host}:#{mx_priority}", 'b', 'c'] }
+
+        it 'returns array of target class instances' do
+          [10, 20, 30].zip(records_data).each_with_index do |(record_preference, record_data), index|
+            expect(target_factory)
+              .to receive(:new)
+              .with(record_data: index.zero? ? [mx_priority, mx_host] : [record_preference, record_data])
+              .and_return(target_factory_instance)
+          end
+          expect(builder).to eq(::Array.new(records_data.size) { target_class_instance })
+        end
       end
-      expect(builder).to eq(::Array.new(records_data.size) { target_class_instance })
+    end
+
+    describe 'Failure' do
+      context 'when invalid records_data nested type' do
+        let(:record_data_object) { 42 }
+        let(:records_data) { [record_data_object] }
+
+        it do
+          expect { builder }.to raise_error(
+            DnsMock::Error::RecordContextType,
+            "#{record_data_object.class} is invalid record context type for MX record. Should be a String"
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Added ability to specify custom priority of MX record if it needed. Now it impossible to define null or backup MX records.

```ruby
require 'dns_mock'

records = {
  'example.com' => {
    mx: %w[.:0 mx1.domain.com:10 mx2.domain.com:10 mx3.domain.com]
  }
}

DnsMock.start_server(records: records)
```

- [x] Updated DnsMock::Record::Builder::Mx, tests
- [x] Updated gem version, readme, changelog