### PR TITLE
Feature/Ability to use internationalized hostnames

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -17,17 +17,23 @@ detectors:
       - DnsMock::ContextGeneratorHelper#random_ip_v4_address
       - DnsMock::ContextGeneratorHelper#random_ip_v6_address
       - DnsMock::ContextGeneratorHelper#random_txt_record_context
+      - DnsMock::ContextGeneratorHelper#to_punycode_hostname
       - DnsMock::RecordsDictionaryHelper#create_records_dictionary_by_records
       - DnsMock::ServerHelper#start_random_server
       - DnsMock::ServerHelper#stop_all_running_servers
-      - DnsMock::Server::RecordsDictionaryBuilder#rdns_lookup_prefix
       - DnsMock::ContextGeneratorHelper#random_port_number
       - DnsMock::TestFramework::RSpec::Helper#dns_mock_server
+      - DnsMock::ContextGeneratorHelper#to_rdns_hostaddress
+
+  DuplicateMethodCall:
+    exclude:
+      - DnsMock::ContextGeneratorHelper#create_records
 
   ControlParameter:
     exclude:
       - DnsMock::Error::Helper#raise_unless
       - DnsMock::Server#initialize
+      - DnsMock::ContextGeneratorHelper#to_punycode_hostname
 
   MissingSafeMethod:
     exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2021-07-13
+
+### Added
+
+- Added ability to use internationalized hostnames. All hostnames in UTF-8 will be represented as [Punycode](https://en.wikipedia.org/wiki/Punycode)
+- Added `simpleidn` as runtime dependency
+- Added `DnsMock::Representer::Punycode`, tests
+
+```ruby
+records = {
+  'mañana.com' => {
+    mx: %w[másletras.mañana.com]
+  }
+}
+
+DnsMock.start_server(port: 5300, records: records)
+```
+
+```bash
+dig @localhost -p 5300 MX xn--maana-pta.com
+```
+
+```
+; <<>> DiG 9.10.6 <<>> @localhost -p 5300 MX xn--maana-pta.com
+; (2 servers found)
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 4612
+;; flags: rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
+;; WARNING: recursion requested but not available
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 4096
+;; QUESTION SECTION:
+;xn--maana-pta.com.		IN	MX
+
+;; ANSWER SECTION:
+xn--maana-pta.com.	1	IN	MX	10 xn--msletras-8ya.xn--maana-pta.com.
+
+;; Query time: 0 msec
+;; SERVER: 127.0.0.1#5300(127.0.0.1)
+;; WHEN: Tue Jul 13 15:38:47 EEST 2021
+;; MSG SIZE  rcvd: 79
+```
+
+### Changed
+
+- Refactored `DnsMock::Representer::RdnsLookup`, tests
+- Updated `DnsMock::Record::Factory::Base`
+- Updated `DnsMock::Server::RecordsDictionaryBuilder`, tests
+- Updated `DnsMock::Record::Factory::Cname`, tests
+- Updated `DnsMock::Record::Factory::Mx`, tests
+- Updated `DnsMock::Record::Factory::Ns`, tests
+- Updated `DnsMock::Record::Factory::Ptr`, tests
+- Updated `DnsMock::Record::Factory::Soa`, tests
+- Updated `DnsMock::ContextGeneratorHelper`, tests
+- Updated reek config
+- Updated gem documentation, version
+
 ## [1.3.1] - 2021-07-07
 
 ### Changed
@@ -12,11 +71,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [1.3.0] - 2021-06-14
 
-Detecting random available port via OS features. Thanks [@ioquatix](https://github.com/ioquatix) for [suggestion](https://github.com/mocktools/ruby-dns-mock/issues/42) 🚀
+### Added
+
+- Detecting random available port via OS features. Thanks [@ioquatix](https://github.com/ioquatix) for [suggestion](https://github.com/mocktools/ruby-dns-mock/issues/42) 🚀
 
 ### Removed
 
-- Removed `DnsMock::Server::RandomAvailablePort`
+- Removed `DnsMock::Server::RandomAvailablePort`, tests
 
 ### Changed
 
@@ -61,9 +122,11 @@ Detecting random available port via OS features. Thanks [@ioquatix](https://gith
 
 ## [1.2.0] - 2021-02-04
 
-### Ability to specify MX record priority
+### Added
 
-Added ability to specify custom priority of MX record if it needed. Now it impossible to define null or backup MX records. Please note, if you haven't specified a priority of MX record, it will be assigned automatically. MX records builder is assigning priority with step 10 from first item of defined MX records array.
+- Ability to specify custom priority of MX record if it needed
+
+Now is possible to define null or backup MX records. Please note, if you haven't specified a priority of MX record, it will be assigned automatically. MX records builder is assigning priority with step 10 from first item of defined MX records array.
 
 ```ruby
 records = {
@@ -96,9 +159,9 @@ example.com.		1	IN	MX	40 mx3.domain.com.
 
 ## [1.1.0] - 2021-02-01
 
-### RSpec native support
+### Added
 
-Added DnsMock helper which can simplify integration with RSpec.
+- RSpec native support. DnsMock helper help you to simplify integration with RSpec
 
 ```ruby
 # spec/support/config/dns_mock.rb
@@ -130,9 +193,11 @@ end
 
 ## [1.0.0] - 2021-01-29
 
-### Configurable record not found behaviour
+### Added
 
-Added configurable strategy for record not found case. By default it won't raise an exception when DNS record not found in mocked records dictionary:
+- Configurable strategy for record not found case
+
+By default it won't raise an exception when DNS record not found in mocked records dictionary:
 
 ```ruby
 DnsMock.start_server(port: 5300)
@@ -178,13 +243,15 @@ DnsMock.start_server(exception_if_not_found: true)
 
 ### Fixed
 
-Fixed RDNS lookup representatin for IP address in PTR record feature.
+- RDNS lookup representatin for IP address in PTR record feature.
 
 ## [0.2.0] - 2021-01-26
 
-### PTR record support
+### Added
 
-Added ability to mock PTR records. Please note, you can define host address without RDNS lookup prefix (`.in-addr.arpa`). `DnsMock` will do it for you.
+- PTR record support. Ability to mock PTR records
+
+Please note, you can define host address without RDNS lookup prefix (`.in-addr.arpa`). `DnsMock` will do it for you.
 
 ```ruby
 records = {
@@ -216,6 +283,6 @@ dig @localhost -p 5300 -x 1.2.3.4
 
 ## [0.1.0] - 2021-01-19
 
-### First release
+### Added
 
-Implemented first version of `DnsMock`. Thanks [@le0pard](https://github.com/le0pard) for idea & support 🚀
+- First release of `DnsMock`. Thanks [@le0pard](https://github.com/le0pard) for idea & support 🚀

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: .
   specs:
-    dns_mock (1.3.1)
+    dns_mock (1.4.0)
+      simpleidn (~> 0.2.1)
 
 GEM
   remote: https://rubygems.org/
@@ -35,7 +36,7 @@ GEM
       iniparse (~> 1.4)
       rexml (~> 3.2)
     parallel (1.20.1)
-    parser (3.0.1.1)
+    parser (3.0.2.0)
       ast (~> 2.4.1)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -45,7 +46,7 @@ GEM
       pry (~> 0.13.0)
     psych (3.3.2)
     rainbow (3.0.0)
-    rake (13.0.4)
+    rake (13.0.6)
     reek (6.0.4)
       kwalify (~> 0.7.0)
       parser (~> 3.0.0)
@@ -108,14 +109,14 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
-  bundler (~> 2.2, >= 2.2.22)
+  bundler (~> 2.2, >= 2.2.23)
   bundler-audit (~> 0.8.0)
   dns_mock!
   faker (~> 2.18)
   fasterer (~> 0.9.0)
   overcommit (~> 0.58.0)
   pry-byebug (~> 3.9)
-  rake (~> 13.0, >= 13.0.4)
+  rake (~> 13.0, >= 13.0.6)
   reek (~> 6.0, >= 6.0.4)
   rspec (~> 3.10)
   rspec-dns (~> 0.1.8)
@@ -125,4 +126,4 @@ DEPENDENCIES
   simplecov (~> 0.17.1)
 
 BUNDLED WITH
-   2.2.22
+   2.2.23

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@
 ## Features
 
 - Ability to mimic any DNS records (`A`, `AAAA`, `CNAME`, `MX`, `NS`, `PTR`, `SOA` and `TXT`)
-- Zero runtime dependencies
+- Automatically converts hostnames to RDNS/[Punycode](https://en.wikipedia.org/wiki/Punycode) representation
 - Lightweight UDP DNS mock server with dynamic/manual port assignment
 - Test framework agnostic (it's PORO, so you can use it outside of `RSpec`, `Test::Unit` or `MiniTest`)
 - Simple and intuitive DSL
+- Only one runtime dependency
 
 ## Requirements
 
@@ -67,7 +68,7 @@ records = {
     ns: %w[ns1.domain.com ns2.domain.com],
     mx: %w[mx1.domain.com mx2.domain.com:50], # you can specify host(s) or host(s) with priority, use '.:0' for definition null MX record
     txt: %w[txt_record_1 txt_record_2],
-    cname: 'some.domain.com',
+    cname: 'mañana.com', # you can specify hostname in UTF-8. It will be converted to xn--maana-pta.com automatically
     soa: [
       {
         mname: 'dns1.domain.com',
@@ -85,7 +86,7 @@ records = {
   }
 }
 
-# Main DnsMock interface
+# Public DnsMock interface
 # records:Hash, port:Integer, exception_if_not_found:Boolean
 # are optional params. By default creates dns mock server with
 # empty records. A free port for server will be randomly assigned
@@ -136,7 +137,7 @@ require 'dns_mock/test_framework/rspec'
 
 #### DnsMock RSpec helper
 
-Just add `DnsMock::TestFramework::RSpec::Helper` if you wanna use shortcut `dns_mock_server` for DnsMock server instance into your `RSpec.describe` blocks:
+Just add `DnsMock::TestFramework::RSpec::Helper` if you wanna use shortcut `dns_mock_server` for DnsMock server instance inside of your `RSpec.describe` blocks:
 
 ```ruby
 # spec/support/config/dns_mock.rb

--- a/dns_mock.gemspec
+++ b/dns_mock.gemspec
@@ -31,13 +31,15 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 2.2', '>= 2.2.22'
+  spec.add_runtime_dependency 'simpleidn', '~> 0.2.1'
+
+  spec.add_development_dependency 'bundler', '~> 2.2', '>= 2.2.23'
   spec.add_development_dependency 'bundler-audit', '~> 0.8.0'
   spec.add_development_dependency 'faker', '~> 2.18'
   spec.add_development_dependency 'fasterer', '~> 0.9.0'
   spec.add_development_dependency 'overcommit', '~> 0.58.0'
   spec.add_development_dependency 'pry-byebug', '~> 3.9'
-  spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.4'
+  spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
   spec.add_development_dependency 'reek', '~> 6.0', '>= 6.0.4'
   spec.add_development_dependency 'rspec', '~> 3.10'
   spec.add_development_dependency 'rspec-dns', '~> 0.1.8'

--- a/lib/dns_mock/core.rb
+++ b/lib/dns_mock/core.rb
@@ -18,6 +18,11 @@ module DnsMock
     require_relative '../dns_mock/error/helper'
   end
 
+  module Representer
+    require_relative '../dns_mock/representer/punycode'
+    require_relative '../dns_mock/representer/rdns_lookup'
+  end
+
   module Record
     module Factory
       require_relative '../dns_mock/record/factory/base'

--- a/lib/dns_mock/record/factory/base.rb
+++ b/lib/dns_mock/record/factory/base.rb
@@ -23,8 +23,13 @@ module DnsMock
           end
         end
 
-        def initialize(dns_name = ::Resolv::DNS::Name, record_data:)
+        def initialize(
+          dns_name = ::Resolv::DNS::Name,
+          punycode_representer = DnsMock::Representer::Punycode,
+          record_data:
+        )
           @dns_name = dns_name
+          @punycode_representer = punycode_representer
           @record_data = record_data
         end
 
@@ -38,7 +43,7 @@ module DnsMock
 
         private
 
-        attr_reader :dns_name, :record_data
+        attr_reader :dns_name, :punycode_representer, :record_data
 
         def record_type
           self.class.name.split('::').last.upcase
@@ -46,7 +51,7 @@ module DnsMock
 
         def create_dns_name(hostname)
           raise ::ArgumentError, "cannot interpret as DNS name: #{hostname}" unless hostname.is_a?(::String)
-          dns_name.create("#{hostname}.")
+          dns_name.create("#{punycode_representer.call(hostname)}.")
         end
       end
     end

--- a/lib/dns_mock/representer/punycode.rb
+++ b/lib/dns_mock/representer/punycode.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Representer
+    Punycode = ::Class.new do
+      require 'simpleidn'
+
+      def self.call(hostname)
+        return hostname if hostname.ascii_only?
+
+        SimpleIDN.to_ascii(hostname)
+      end
+    end
+  end
+end

--- a/lib/dns_mock/representer/rdns_lookup.rb
+++ b/lib/dns_mock/representer/rdns_lookup.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module DnsMock
+  module Representer
+    class RdnsLookup
+      IP_OCTET_GROUPS = /(\d+).(\d+).(\d+).(\d+)/.freeze
+      RDNS_LOOKUP_REPRESENTATION = '\4.\3.\2.\1.in-addr.arpa'
+
+      def self.call(host_address)
+        host_address.gsub(
+          DnsMock::Representer::RdnsLookup::IP_OCTET_GROUPS,
+          DnsMock::Representer::RdnsLookup::RDNS_LOOKUP_REPRESENTATION
+        )
+      end
+    end
+  end
+end

--- a/lib/dns_mock/version.rb
+++ b/lib/dns_mock/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DnsMock
-  VERSION = '1.3.1'
+  VERSION = '1.4.0'
 end

--- a/spec/dns_mock/record/factory/cname_spec.rb
+++ b/spec/dns_mock/record/factory/cname_spec.rb
@@ -20,11 +20,26 @@ RSpec.describe DnsMock::Record::Factory::Cname do
     subject(:create_factory) { described_class.new(record_data: record_data).create }
 
     context 'when valid record context' do
-      let(:record_data) { random_hostname }
+      shared_examples 'returns instance of target class' do
+        it 'returns instance of target class' do
+          expect(DnsMock::Representer::Punycode).to receive(:call).with(record_data).and_call_original
+          expect(create_factory).to be_an_instance_of(described_class.target_class)
+          expect(create_factory.name.to_s).to eq(converted_record_data)
+        end
+      end
 
-      it 'returns instance of target class' do
-        expect(create_factory).to be_an_instance_of(described_class.target_class)
-        expect(create_factory.name.to_s).to eq(record_data)
+      context 'when ASCII hostname' do
+        let(:record_data) { random_hostname }
+        let(:converted_record_data) { record_data }
+
+        include_examples 'returns instance of target class'
+      end
+
+      context 'when non ASCII hostname' do
+        let(:record_data) { random_non_ascii_hostname }
+        let(:converted_record_data) { to_punycode_hostname(record_data) }
+
+        include_examples 'returns instance of target class'
       end
     end
 

--- a/spec/dns_mock/record/factory/mx_spec.rb
+++ b/spec/dns_mock/record/factory/mx_spec.rb
@@ -20,12 +20,29 @@ RSpec.describe DnsMock::Record::Factory::Mx do
     subject(:create_factory) { described_class.new(record_data: record_data).create }
 
     context 'when valid record context' do
-      let(:record_data) { [10, random_hostname] }
+      let(:record_data) { [10, hostname] }
 
-      it 'returns instance of target class' do
-        expect(create_factory).to be_an_instance_of(described_class.target_class)
-        expect(create_factory.preference).to eq(record_data.first)
-        expect(create_factory.exchange.to_s).to eq(record_data.last)
+      shared_examples 'returns instance of target class' do
+        it 'returns instance of target class' do
+          expect(DnsMock::Representer::Punycode).to receive(:call).with(hostname).and_call_original
+          expect(create_factory).to be_an_instance_of(described_class.target_class)
+          expect(create_factory.preference).to eq(record_data.first)
+          expect(create_factory.exchange.to_s).to eq(converted_hostname)
+        end
+      end
+
+      context 'when ASCII hostname' do
+        let(:hostname) { random_hostname }
+        let(:converted_hostname) { hostname }
+
+        include_examples 'returns instance of target class'
+      end
+
+      context 'when non ASCII hostname' do
+        let(:hostname) { random_non_ascii_hostname }
+        let(:converted_hostname) { to_punycode_hostname(hostname) }
+
+        include_examples 'returns instance of target class'
       end
     end
 

--- a/spec/dns_mock/record/factory/ns_spec.rb
+++ b/spec/dns_mock/record/factory/ns_spec.rb
@@ -20,11 +20,26 @@ RSpec.describe DnsMock::Record::Factory::Ns do
     subject(:create_factory) { described_class.new(record_data: record_data).create }
 
     context 'when valid record context' do
-      let(:record_data) { random_hostname }
+      shared_examples 'returns instance of target class' do
+        it 'returns instance of target class' do
+          expect(DnsMock::Representer::Punycode).to receive(:call).with(record_data).and_call_original
+          expect(create_factory).to be_an_instance_of(described_class.target_class)
+          expect(create_factory.name.to_s).to eq(converted_record_data)
+        end
+      end
 
-      it 'returns instance of target class' do
-        expect(create_factory).to be_an_instance_of(described_class.target_class)
-        expect(create_factory.name.to_s).to eq(record_data)
+      context 'when ASCII hostname' do
+        let(:record_data) { random_hostname }
+        let(:converted_record_data) { record_data }
+
+        include_examples 'returns instance of target class'
+      end
+
+      context 'when non ASCII hostname' do
+        let(:record_data) { random_non_ascii_hostname }
+        let(:converted_record_data) { to_punycode_hostname(record_data) }
+
+        include_examples 'returns instance of target class'
       end
     end
 

--- a/spec/dns_mock/record/factory/ptr_spec.rb
+++ b/spec/dns_mock/record/factory/ptr_spec.rb
@@ -20,11 +20,26 @@ RSpec.describe DnsMock::Record::Factory::Ptr do
     subject(:create_factory) { described_class.new(record_data: record_data).create }
 
     context 'when valid record context' do
-      let(:record_data) { random_hostname }
+      shared_examples 'returns instance of target class' do
+        it 'returns instance of target class' do
+          expect(DnsMock::Representer::Punycode).to receive(:call).with(record_data).and_call_original
+          expect(create_factory).to be_an_instance_of(described_class.target_class)
+          expect(create_factory.name.to_s).to eq(converted_record_data)
+        end
+      end
 
-      it 'returns instance of target class' do
-        expect(create_factory).to be_an_instance_of(described_class.target_class)
-        expect(create_factory.name.to_s).to eq(record_data)
+      context 'when ASCII hostname' do
+        let(:record_data) { random_hostname }
+        let(:converted_record_data) { record_data }
+
+        include_examples 'returns instance of target class'
+      end
+
+      context 'when non ASCII hostname' do
+        let(:record_data) { random_non_ascii_hostname }
+        let(:converted_record_data) { to_punycode_hostname(record_data) }
+
+        include_examples 'returns instance of target class'
       end
     end
 

--- a/spec/dns_mock/record/factory/soa_spec.rb
+++ b/spec/dns_mock/record/factory/soa_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe DnsMock::Record::Factory::Soa do
 
     let(:record_data) do
       {
-        mname: random_hostname,
-        rname: random_hostname,
+        mname: mname,
+        rname: rname,
         serial: 2_035_971_683,
         refresh: 10_000,
         retry: 2_400,
@@ -36,10 +36,52 @@ RSpec.describe DnsMock::Record::Factory::Soa do
       }
     end
 
-    it 'returns instance of target class' do
-      expect(create_factory).to be_an_instance_of(described_class.target_class)
-      dns_names = record_data.slice(:mname, :rname).transform_values { |value| create_dns_name(value) }
-      record_data.merge(dns_names).each { |key, value| expect(create_factory.public_send(key)).to eq(value) }
+    context 'when valid record context' do
+      shared_examples 'returns instance of target class' do
+        it 'returns instance of target class' do
+          expect(DnsMock::Representer::Punycode).to receive(:call).with(mname).and_call_original
+          expect(DnsMock::Representer::Punycode).to receive(:call).with(rname).and_call_original
+          expect(create_factory).to be_an_instance_of(described_class.target_class)
+          dns_names = record_data.slice(:mname, :rname).transform_values do |value|
+            create_dns_name(ascii_hostname ? value : to_punycode_hostname(value))
+          end
+          record_data.merge(dns_names).each { |key, value| expect(create_factory.public_send(key)).to eq(value) }
+        end
+      end
+
+      context 'when ASCII hostname' do
+        let(:ascii_hostname) { true }
+        let(:mname) { random_hostname }
+        let(:rname) { random_hostname }
+
+        include_examples 'returns instance of target class'
+      end
+
+      context 'when non ASCII hostname' do
+        let(:ascii_hostname) { false }
+        let(:mname) { random_non_ascii_hostname }
+        let(:rname) { random_non_ascii_hostname }
+
+        include_examples 'returns instance of target class'
+      end
+    end
+
+    context 'when invalid record context' do
+      context 'when invalid mname' do
+        let(:mname) { 42 }
+        let(:rname) { random_hostname }
+        let(:error_context) { "cannot interpret as DNS name: #{mname}. Invalid SOA record context" }
+
+        it_behaves_like 'target class exception wrapper'
+      end
+
+      context 'when invalid rname' do
+        let(:mname) { random_hostname }
+        let(:rname) { 42 }
+        let(:error_context) { "cannot interpret as DNS name: #{rname}. Invalid SOA record context" }
+
+        it_behaves_like 'target class exception wrapper'
+      end
     end
   end
 end

--- a/spec/dns_mock/representer/punycode_spec.rb
+++ b/spec/dns_mock/representer/punycode_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Representer::Punycode do
+  describe '.call' do
+    subject(:punycode_representer) { described_class.call(hostname) }
+
+    context 'when hostname includes ASCII chars only' do
+      let(:hostname) { random_hostname }
+
+      it 'returns hostname without convertion' do
+        expect(SimpleIDN).not_to receive(:to_ascii).with(hostname)
+        expect(punycode_representer).to eq(hostname)
+      end
+    end
+
+    context 'when hostname includes not ASCII chars' do
+      let(:hostname) { 'mañana.cøm' }
+
+      it 'returns converted to ASCII hostname' do
+        expect(SimpleIDN).to receive(:to_ascii).with(hostname).and_call_original
+        expect(punycode_representer).to eq('xn--maana-pta.xn--cm-lka')
+      end
+    end
+  end
+end

--- a/spec/dns_mock/representer/rdns_lookup_spec.rb
+++ b/spec/dns_mock/representer/rdns_lookup_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe DnsMock::Representer::RdnsLookup do
+  describe 'defined constants' do
+    it { expect(described_class).to be_const_defined(:IP_OCTET_GROUPS) }
+    it { expect(described_class).to be_const_defined(:RDNS_LOOKUP_REPRESENTATION) }
+  end
+
+  describe '.call' do
+    subject(:rdns_lookup_representer) { described_class.call(host_address) }
+
+    context 'when hostname includes ASCII chars only' do
+      let(:host_address) { random_ip_v4_address }
+      let(:rdns_lookup_prefix) { '.in-addr.arpa' }
+      let(:rdns_lookup_host_address_representation) do
+        "#{host_address.split('.').reverse.join('.')}#{rdns_lookup_prefix}"
+      end
+
+      it 'returns hostname without convertion' do
+        expect(rdns_lookup_representer).to eq(rdns_lookup_host_address_representation)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added ability to use internationalized hostnames. All hostnames in UTF-8 will be represented as [Punycode](https://en.wikipedia.org/wiki/Punycode).

```ruby
DnsMock.start_server(port: 5300, records: { 'mañana.com' => { mx: %w[másletras.mañana.com] })
```

```bash
dig @localhost -p 5300 MX xn--maana-pta.com
```

```
; <<>> DiG 9.10.6 <<>> @localhost -p 5300 MX xn--maana-pta.com
; (2 servers found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 4612
;; flags: rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;xn--maana-pta.com.		IN	MX

;; ANSWER SECTION:
xn--maana-pta.com.	1	IN	MX	10 xn--msletras-8ya.xn--maana-pta.com.

;; Query time: 0 msec
;; SERVER: 127.0.0.1#5300(127.0.0.1)
;; WHEN: Tue Jul 13 15:38:47 EEST 2021
;; MSG SIZE  rcvd: 79
```

- [x] Added `simpleidn` as runtime dependency
- [x] Implemented `DnsMock::Representer::Punycode`, tests
- [x] Refactored `DnsMock::Representer::RdnsLookup`, tests
- [x] Updated `DnsMock::Record::Factory::Base`
- [x] Updated `DnsMock::Server::RecordsDictionaryBuilder`, tests
- [x] Updated `DnsMock::Record::Factory::Cname`, tests
- [x] Updated `DnsMock::Record::Factory::Mx`, tests
- [x] Updated `DnsMock::Record::Factory::Ns`, tests
- [x] Updated `DnsMock::Record::Factory::Ptr`, tests
- [x] Updated `DnsMock::Record::Factory::Soa`, tests
- [x] Updated `DnsMock::ContextGeneratorHelper`, tests
- [x] Updated reek config
- [x] Updated gem documentation, version