### PR TITLE
Fix: assign_mocks should update records regardless of current state

### DIFF
--- a/lib/dns_mock/server.rb
+++ b/lib/dns_mock/server.rb
@@ -49,7 +49,7 @@ module DnsMock
     end
 
     def assign_mocks(new_records)
-      !!self.records = records_dictionary_builder.call(new_records) if records.empty?
+      !!self.records = records_dictionary_builder.call(new_records)
     end
 
     def reset_mocks!


### PR DESCRIPTION
## Problem

The `assign_mocks` method in `lib/dns_mock/server.rb` only updates the records hash when it is currently empty:

```ruby
def assign_mocks(new_records)
  !!self.records = records_dictionary_builder.call(new_records) if records.empty?
end
```

This prevents users from updating existing mock configurations after the server has been initialized with records.

## Solution

Remove the conditional check so that `assign_mocks` always updates the records:

```ruby
def assign_mocks(new_records)
  !!self.records = records_dictionary_builder.call(new_records)
end
```

## Impact

- Users can now update mock DNS records at any time, not just when the records hash is empty
- This is the expected behavior for a method named `assign_mocks` - it should assign/update the mocks

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.